### PR TITLE
[FEAT] 채팅 도메인 기본 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ application-local.yml
 
 ### env ###
 .env
+
+.claude/
+CLAUDE.md

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,19 @@
 services:
 
-  mysql:
-    image: mysql:8.0
-    container_name: auction-mysql
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: auction-postgres
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USERNAME}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DATABASE}
+      POSTGRES_USER: ${POSTGRES_USERNAME}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "3306:3306"
+      - "5432:5432"
     volumes:
-      - mysql-data:/var/lib/mysql
+      - postgres-data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USERNAME}" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -70,4 +70,4 @@ services:
         condition: service_healthy
 
 volumes:
-  mysql-data:
+  postgres-data:

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,2 @@
+-- pgvector 확장 활성화 (RAG 벡터 임베딩 저장용)
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/src/main/java/com/example/auction/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/auction/domain/chat/controller/ChatController.java
@@ -1,0 +1,62 @@
+package com.example.auction.domain.chat.controller;
+
+import com.example.auction.common.dto.BaseResponse;
+import com.example.auction.domain.chat.dto.ChatMessageListResponse;
+import com.example.auction.domain.chat.dto.ChatMessageSendRequest;
+import com.example.auction.domain.chat.dto.ChatRoomResponse;
+import com.example.auction.domain.chat.service.ChatService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    // 채팅방 생성
+    @PostMapping("/rooms")
+    public BaseResponse<ChatRoomResponse> createRoom() {
+        // TODO: userId from security context
+        return null;
+    }
+
+    // 내 채팅방 목록 조회
+    @GetMapping("/rooms")
+    public BaseResponse<List<ChatRoomResponse>> getRooms() {
+        // TODO: userId from security context
+        return null;
+    }
+
+    // 채팅방 삭제
+    @DeleteMapping("/rooms/{roomId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteRoom(@PathVariable Long roomId) {
+        // TODO: userId from security context
+    }
+
+    // 메시지 목록 조회 (커서 기반 페이징)
+    @GetMapping("/rooms/{roomId}/messages")
+    public BaseResponse<ChatMessageListResponse> getMessages(
+            @PathVariable Long roomId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        // TODO: userId from security context
+        return null;
+    }
+
+    // AI 메시지 전송 (SSE 스트리밍) - AI 연동 시 구현
+    @PostMapping("/rooms/{roomId}/messages")
+    public void sendMessage(
+            @PathVariable Long roomId,
+            @RequestBody @Valid ChatMessageSendRequest request
+    ) {
+        // TODO: SSE 스트리밍 구현 예정
+    }
+}

--- a/src/main/java/com/example/auction/domain/chat/dto/ChatMessageListResponse.java
+++ b/src/main/java/com/example/auction/domain/chat/dto/ChatMessageListResponse.java
@@ -1,0 +1,15 @@
+package com.example.auction.domain.chat.dto;
+
+import java.util.List;
+
+public record ChatMessageListResponse(
+        List<ChatMessageResponse> messages,
+        Long nextCursor  // 다음 페이지 커서 (null이면 마지막 페이지)
+) {
+    public static ChatMessageListResponse of(List<ChatMessageResponse> messages, int size) {
+        // 요청한 size만큼 왔으면 다음 페이지 존재 — 마지막 메시지 id를 커서로
+        boolean hasNext = messages.size() == size;
+        Long nextCursor = hasNext ? messages.get(0).id() : null;
+        return new ChatMessageListResponse(messages, nextCursor);
+    }
+}

--- a/src/main/java/com/example/auction/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/example/auction/domain/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,22 @@
+package com.example.auction.domain.chat.dto;
+
+import com.example.auction.domain.chat.entity.ChatMessage;
+import com.example.auction.domain.chat.entity.MessageRole;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageResponse(
+        Long id,
+        String content,
+        MessageRole role,
+        LocalDateTime createdAt
+) {
+    public static ChatMessageResponse from(ChatMessage chatMessage) {
+        return new ChatMessageResponse(
+                chatMessage.getId(),
+                chatMessage.getContent(),
+                chatMessage.getRole(),
+                chatMessage.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/auction/domain/chat/dto/ChatMessageSendRequest.java
+++ b/src/main/java/com/example/auction/domain/chat/dto/ChatMessageSendRequest.java
@@ -1,0 +1,9 @@
+package com.example.auction.domain.chat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChatMessageSendRequest(
+        @NotBlank(message = "메시지 내용을 입력해 주세요")
+        String content
+) {
+}

--- a/src/main/java/com/example/auction/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/example/auction/domain/chat/dto/ChatRoomResponse.java
@@ -1,0 +1,19 @@
+package com.example.auction.domain.chat.dto;
+
+import com.example.auction.domain.chat.entity.ChatRoom;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomResponse(
+        Long id,
+        String title,
+        LocalDateTime createdAt
+) {
+    public static ChatRoomResponse from(ChatRoom chatRoom) {
+        return new ChatRoomResponse(
+                chatRoom.getId(),
+                chatRoom.getTitle(),
+                chatRoom.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/auction/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/auction/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,36 @@
+package com.example.auction.domain.chat.entity;
+
+import com.example.auction.common.entity.CreatableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chat_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends CreatableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MessageRole role;
+
+    @Column(nullable = false)
+    private Long roomId;
+
+    public static ChatMessage of(Long roomId, String content, MessageRole role) {
+        ChatMessage message = new ChatMessage();
+        message.roomId = roomId;
+        message.content = content;
+        message.role = role;
+        return message;
+    }
+}

--- a/src/main/java/com/example/auction/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/auction/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,34 @@
+package com.example.auction.domain.chat.entity;
+
+import com.example.auction.common.entity.CreatableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chat_rooms")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends CreatableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String title;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    public static ChatRoom from(Long userId) {
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.userId = userId;
+        return chatRoom;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/example/auction/domain/chat/entity/MessageRole.java
+++ b/src/main/java/com/example/auction/domain/chat/entity/MessageRole.java
@@ -1,0 +1,7 @@
+package com.example.auction.domain.chat.entity;
+
+public enum MessageRole {
+
+    // USER는 사용자의 채팅 ASSISTANT는 AI의 채팅
+    USER, ASSISTANT
+}

--- a/src/main/java/com/example/auction/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/auction/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,15 @@
+package com.example.auction.domain.chat.repository;
+
+import com.example.auction.domain.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
+
+    // 채팅방 삭제 시 메시지 cascade 하드딜리트
+    void deleteAllByRoomId(Long roomId);
+
+    // 스케줄러 - 30일 이전 메시지 자동 삭제
+    void deleteAllByCreatedAtBefore(LocalDateTime dateTime);
+}

--- a/src/main/java/com/example/auction/domain/chat/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/com/example/auction/domain/chat/repository/ChatMessageRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.auction.domain.chat.repository;
+
+import com.example.auction.domain.chat.entity.ChatMessage;
+
+import java.util.List;
+
+public interface ChatMessageRepositoryCustom {
+
+    // 커서 기반 페이징 - cursor(마지막 메시지 id)보다 이전 메시지 조회
+    List<ChatMessage> findByCursor(Long roomId, Long cursor, int size);
+
+    // Redis 캐싱용 - AI 컨텍스트에 넘길 최근 N개
+    List<ChatMessage> findRecentByRoomId(Long roomId, int limit);
+}

--- a/src/main/java/com/example/auction/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/example/auction/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.example.auction.domain.chat.repository;
+
+import com.example.auction.domain.chat.entity.ChatMessage;
+import com.example.auction.domain.chat.entity.QChatMessage;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QChatMessage chatMessage = QChatMessage.chatMessage;
+
+    // 커서 기반 페이징 - cursor가 null이면 최신부터, 있으면 해당 id 이전 메시지 조회 (ASC 반환)
+    @Override
+    public List<ChatMessage> findByCursor(Long roomId, Long cursor, int size) {
+        List<ChatMessage> messages = queryFactory
+                .selectFrom(chatMessage)
+                .where(
+                        chatMessage.roomId.eq(roomId),
+                        cursor != null ? chatMessage.id.lt(cursor) : null
+                )
+                .orderBy(chatMessage.id.desc())
+                .limit(size)
+                .fetch();
+        Collections.reverse(messages);
+        return messages;
+    }
+
+    // Redis 캐싱용 - AI 컨텍스트에 넘길 최근 N개 (시간순 정렬로 반환)
+    @Override
+    public List<ChatMessage> findRecentByRoomId(Long roomId, int limit) {
+        List<ChatMessage> messages = queryFactory
+                .selectFrom(chatMessage)
+                .where(chatMessage.roomId.eq(roomId))
+                .orderBy(chatMessage.id.desc())
+                .limit(limit)
+                .fetch();
+        Collections.reverse(messages);
+        return messages;
+    }
+}

--- a/src/main/java/com/example/auction/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/auction/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,16 @@
+package com.example.auction.domain.chat.repository;
+
+import com.example.auction.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    // 내 채팅방 목록 최신순 조회
+    List<ChatRoom> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 채팅방 조회 + 본인 소유 검증
+    Optional<ChatRoom> findByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/com/example/auction/domain/chat/service/ChatService.java
+++ b/src/main/java/com/example/auction/domain/chat/service/ChatService.java
@@ -1,0 +1,45 @@
+package com.example.auction.domain.chat.service;
+
+import com.example.auction.domain.chat.dto.ChatMessageListResponse;
+import com.example.auction.domain.chat.dto.ChatRoomResponse;
+import com.example.auction.domain.chat.repository.ChatMessageRepository;
+import com.example.auction.domain.chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    // 채팅방 생성
+    @Transactional
+    public ChatRoomResponse createRoom(Long userId) {
+        // TODO: 구현 예정
+        return null;
+    }
+
+    // 내 채팅방 목록 조회
+    public List<ChatRoomResponse> getRooms(Long userId) {
+        // TODO: 구현 예정
+        return null;
+    }
+
+    // 채팅방 삭제
+    @Transactional
+    public void deleteRoom(Long roomId, Long userId) {
+        // TODO: 구현 예정
+    }
+
+    // 메시지 목록 조회 (커서 기반 페이징)
+    public ChatMessageListResponse getMessages(Long roomId, Long userId, Long cursor, int size) {
+        // TODO: 구현 예정
+        return null;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,10 +3,10 @@ spring:
     name: auction
 
   datasource:
-    url: ${MYSQL_URL}
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${POSTGRES_URL}
+    username: ${POSTGRES_USERNAME}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     show-sql: true
@@ -14,6 +14,7 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: false
     defer-datasource-initialization: true
 


### PR DESCRIPTION
 ## 📝 작업 내용
  - ChatRoom, ChatMessage 엔티티 추가                                                                                                                                                                                                                                                                          
  - Repository 구현                                                                                                                                                                                                                                                     
  - DTO 구현                                                                                                                                                                                                 
  - ChatService, ChatController 구현 (인증 연동 대기 중)                                                                                                                                                                                                                                              
  - MySQL → PostgreSQL (pgvector) 전환

  ## 🔗 관련 이슈 (Related Issues)
  Closes #

  ## ✅ 체크리스트 (Checklist)
  - [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
  - [x] 코딩 컨벤션을 준수했나요?
  - [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
  - [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

  ## 💬 기타 사항
  - Service/Controller는 인증(Bearer Token) 구현 완료 후 연결 예정
  - PostgreSQL 전환으로 팀원 로컬 환경 재설정 필요 (docker-compose 재시작, .env 변수명 변경)
