### PR TITLE
[FIX] JWT 인증 보안 개선 (코드래빗 리뷰 반영)

### DIFF
--- a/src/main/java/com/example/auction/common/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/auction/common/config/security/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtProvider.resolveToken(request.getHeader("Authorization"));
 
-        boolean isValid = token != null && jwtProvider.validateToken(token);
+        boolean isValid = token != null && jwtProvider.validateAccessToken(token);
         boolean blacklisted = true;
 
         if (isValid) {

--- a/src/main/java/com/example/auction/common/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/auction/common/config/security/JwtAuthenticationFilter.java
@@ -38,6 +38,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         if (isValid && !blacklisted) {
+            request.setAttribute("accessToken", token);
+
             Long userId = jwtProvider.getUserId(token);
             String role = jwtProvider.getRole(token);
 

--- a/src/main/java/com/example/auction/common/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/auction/common/config/security/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -12,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -24,8 +26,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtProvider.resolveToken(request.getHeader("Authorization"));
 
-        if (token != null && jwtProvider.validateToken(token)
-                && Boolean.FALSE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + token))) {
+        boolean isValid = token != null && jwtProvider.validateToken(token);
+        boolean blacklisted = true;
+
+        if (isValid) {
+            try {
+                blacklisted = Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + token));
+            } catch (Exception e) {
+                log.error("Redis blacklist 확인 실패: {}", e.getMessage());
+            }
+        }
+
+        if (isValid && !blacklisted) {
             Long userId = jwtProvider.getUserId(token);
             String role = jwtProvider.getRole(token);
 

--- a/src/main/java/com/example/auction/common/config/security/JwtProvider.java
+++ b/src/main/java/com/example/auction/common/config/security/JwtProvider.java
@@ -41,6 +41,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("role", role)
+                .claim("tokenType", "ACCESS")
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + accessTokenExpireTime))
                 .signWith(key)
@@ -52,6 +53,7 @@ public class JwtProvider {
         Date now = new Date();
         return Jwts.builder()
                 .subject(String.valueOf(userId))
+                .claim("tokenType", "REFRESH")
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + refreshTokenExpireTime))
                 .signWith(key)
@@ -71,16 +73,12 @@ public class JwtProvider {
         return expiration.getTime() - System.currentTimeMillis();
     }
 
-    public boolean validateToken(String token) {
-        try {
-            getClaims(token);
-            return true;
-        } catch (ExpiredJwtException e) {
-            log.warn("만료된 JWT 토큰: {}", e.getMessage());
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("유효하지 않은 JWT 토큰: {}", e.getMessage());
-        }
-        return false;
+    public boolean validateAccessToken(String token) {
+        return validateToken(token, "ACCESS");
+    }
+
+    public boolean validateRefreshToken(String token) {
+        return validateToken(token, "REFRESH");
     }
 
     public String resolveToken(String token) {
@@ -88,6 +86,18 @@ public class JwtProvider {
             return token.substring(7);
         }
         return null;
+    }
+
+    private boolean validateToken(String token, String tokenType) {
+        try {
+            Claims claims = getClaims(token);
+            return tokenType.equals(claims.get("tokenType", String.class));
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰: {}", e.getMessage());
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("유효하지 않은 JWT 토큰: {}", e.getMessage());
+        }
+        return false;
     }
 
     private Claims getClaims(String token) {

--- a/src/main/java/com/example/auction/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/auction/domain/auth/controller/AuthController.java
@@ -1,13 +1,13 @@
 package com.example.auction.domain.auth.controller;
 
 import com.example.auction.common.config.security.CustomUserDetails;
-import com.example.auction.common.config.security.JwtProvider;
 import com.example.auction.common.dto.BaseResponse;
 import com.example.auction.domain.auth.dto.AuthLoginRequest;
 import com.example.auction.domain.auth.dto.AuthLoginResponse;
 import com.example.auction.domain.auth.dto.AuthSignupRequest;
 import com.example.auction.domain.auth.dto.AuthSignupResponse;
 import com.example.auction.domain.auth.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-    private final JwtProvider jwtProvider;
 
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<AuthSignupResponse>> signup(@Valid @RequestBody AuthSignupRequest request) {
@@ -44,9 +43,10 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<Void>> logout(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestHeader("Authorization") String accessToken
+            HttpServletRequest request
     ) {
-        authService.logout(userDetails.getUserId(), jwtProvider.resolveToken(accessToken));
+        String accessToken = (String) request.getAttribute("accessToken");
+        authService.logout(userDetails.getUserId(), accessToken);
         return ResponseEntity.ok(BaseResponse.success(HttpStatus.OK.name(), "로그아웃 요청 성공", null));
     }
 }

--- a/src/main/java/com/example/auction/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/auction/domain/auth/service/AuthService.java
@@ -72,7 +72,7 @@ public class AuthService {
 
     @Transactional
     public AuthLoginResponse refreshToken(String refreshToken) {
-        if (!jwtProvider.validateToken(refreshToken)) {
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
             throw new ServiceErrorException(AuthErrorEnum.INVALID_TOKEN);
         }
 


### PR DESCRIPTION
## 📝 작업 내용
- Redis 장애 시 JWT 블랙리스트 확인 실패로 인한 인증 오류 방지 (fail-closed)                                                                                                                           
- refresh token과 access token 타입 구분으로 토큰 혼용(권한 우회) 방지
- 로그아웃 시 resolveToken 중복 호출 제거 및 NPE 방지

### JwtAuthenticationFilter
- Redis 장애 시 `blacklisted = true` 기본값으로 fail-closed 처리
- `validateToken` → `validateAccessToken`으로 교체

### JwtProvider
- `tokenType` 클레임 추가 (`ACCESS` / `REFRESH`)
- `validateAccessToken()`, `validateRefreshToken()` 메서드 추가

### AuthController / JwtAuthenticationFilter
- 필터에서 파싱한 토큰을 `request.setAttribute`로 저장
- 컨트롤러에서 `resolveToken()` 중복 호출 제거

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항
`AuthSignupRequest`의 role 필드는 일단 유지, 추후 admin 전용 API로 분리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tokens now include type information for distinct validation of access and refresh tokens
  * Implemented token blacklist to prevent unauthorized reuse of logged-out tokens

* **Security Improvements**
  * Strengthened JWT authentication validation with enhanced security checks
  * Improved logout endpoint security through better token handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->