### PR TITLE
[FEAT] User 기본 기능 구현

### DIFF
--- a/src/main/java/com/example/auction/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/example/auction/domain/auction/repository/AuctionRepository.java
@@ -1,11 +1,15 @@
 package com.example.auction.domain.auction.repository;
 
+import com.example.auction.domain.auction.enums.AuctionStatus;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.auction.domain.auction.entity.Auction;
 
+import java.util.List;
+
 public interface AuctionRepository extends
     JpaRepository<@NonNull Auction, @NonNull Long>, CustomAuctionRepository
 {
+    boolean existsByUserIdAndStatusIn(Long userId, List<AuctionStatus> auctionStatuses);
 }

--- a/src/main/java/com/example/auction/domain/auth/exception/AuthErrorEnum.java
+++ b/src/main/java/com/example/auction/domain/auth/exception/AuthErrorEnum.java
@@ -10,7 +10,8 @@ public enum AuthErrorEnum implements ErrorEnumInterface {
     // 인증/인가 관련
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일입니다"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다");
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/auction/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/auction/domain/auth/service/AuthService.java
@@ -50,7 +50,7 @@ public class AuthService {
 
     @Transactional
     public AuthLoginResponse login(AuthLoginRequest request) {
-        User user = userRepository.findByEmail(request.email()).orElseThrow(
+        User user = userRepository.findByEmailAndDeletedFalse(request.email()).orElseThrow(
                 () -> new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
@@ -83,7 +83,7 @@ public class AuthService {
             throw new ServiceErrorException(AuthErrorEnum.INVALID_TOKEN);
         }
 
-        User user = userRepository.findById(userId).orElseThrow(
+        User user = userRepository.findByIdAndDeletedFalse(userId).orElseThrow(
                 () -> new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND));
 
         String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());

--- a/src/main/java/com/example/auction/domain/bid/repository/BidRepository.java
+++ b/src/main/java/com/example/auction/domain/bid/repository/BidRepository.java
@@ -1,6 +1,7 @@
 package com.example.auction.domain.bid.repository;
 
 import com.example.auction.domain.bid.entity.Bid;
+import com.example.auction.domain.bid.enums.BidAuctionStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,6 @@ public interface BidRepository extends JpaRepository<Bid, Long>, BidCustomReposi
 
     @Query("SELECT MIN(b.price) FROM Bid b WHERE b.auctionId = :auctionId")
     Optional<Long> findMinPriceByAuctionId(@Param("auctionId") Long auctionId);
+
+    boolean existsByUserIdAndStatus(Long userId, BidAuctionStatus bidAuctionStatus);
 }

--- a/src/main/java/com/example/auction/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/auction/domain/user/controller/UserController.java
@@ -1,7 +1,14 @@
 package com.example.auction.domain.user.controller;
 
+import com.example.auction.common.config.security.CustomUserDetails;
+import com.example.auction.common.dto.BaseResponse;
+import com.example.auction.domain.user.dto.UserGetResponse;
 import com.example.auction.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<UserGetResponse>> myPage(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
+                HttpStatus.OK.name(), "마이페이지 조회 요청 성공", userService.myPage(userId)));
+    }
 }

--- a/src/main/java/com/example/auction/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/auction/domain/user/controller/UserController.java
@@ -1,0 +1,14 @@
+package com.example.auction.domain.user.controller;
+
+import com.example.auction.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+}

--- a/src/main/java/com/example/auction/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/auction/domain/user/controller/UserController.java
@@ -2,15 +2,15 @@ package com.example.auction.domain.user.controller;
 
 import com.example.auction.common.config.security.CustomUserDetails;
 import com.example.auction.common.dto.BaseResponse;
+import com.example.auction.domain.user.dto.UserChangePasswordRequest;
 import com.example.auction.domain.user.dto.UserGetResponse;
 import com.example.auction.domain.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +26,16 @@ public class UserController {
         Long userId = userDetails.getUserId();
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
                 HttpStatus.OK.name(), "마이페이지 조회 요청 성공", userService.myPage(userId)));
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<BaseResponse<Void>> changePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserChangePasswordRequest request
+    ) {
+        Long userId = userDetails.getUserId();
+        userService.changePassword(userId, request);
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
+                HttpStatus.OK.name(), "비밀번호 변경 요청 성공", null));
     }
 }

--- a/src/main/java/com/example/auction/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/auction/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.example.auction.common.config.security.CustomUserDetails;
 import com.example.auction.common.dto.BaseResponse;
 import com.example.auction.domain.user.dto.UserChangePasswordRequest;
 import com.example.auction.domain.user.dto.UserGetResponse;
+import com.example.auction.domain.user.dto.UserWithdrawResponse;
 import com.example.auction.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +38,14 @@ public class UserController {
         userService.changePassword(userId, request);
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
                 HttpStatus.OK.name(), "비밀번호 변경 요청 성공", null));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<BaseResponse<UserWithdrawResponse>> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
+                HttpStatus.OK.name(), "탈퇴 요청 성공", userService.withdraw(userId)));
     }
 }

--- a/src/main/java/com/example/auction/domain/user/dto/UserChangePasswordRequest.java
+++ b/src/main/java/com/example/auction/domain/user/dto/UserChangePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.example.auction.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserChangePasswordRequest(
+        @NotBlank(message = "기존 비밀번호를 입력해주세요")
+        String oldPassword,
+
+        @NotBlank(message = "새 비밀번호를 입력해주세요")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다")
+        String newPassword
+) {}

--- a/src/main/java/com/example/auction/domain/user/dto/UserGetResponse.java
+++ b/src/main/java/com/example/auction/domain/user/dto/UserGetResponse.java
@@ -1,0 +1,12 @@
+package com.example.auction.domain.user.dto;
+
+import com.example.auction.domain.user.enums.UserRole;
+
+import java.math.BigDecimal;
+
+public record UserGetResponse(
+        Long userId,
+        String email,
+        BigDecimal rating,
+        UserRole userRole
+) {}

--- a/src/main/java/com/example/auction/domain/user/dto/UserWithdrawResponse.java
+++ b/src/main/java/com/example/auction/domain/user/dto/UserWithdrawResponse.java
@@ -1,0 +1,13 @@
+package com.example.auction.domain.user.dto;
+
+import com.example.auction.domain.user.enums.UserRole;
+
+import java.time.LocalDateTime;
+
+public record UserWithdrawResponse(
+        Long userId,
+        String email,
+        UserRole role,
+        LocalDateTime createdAt,
+        LocalDateTime deletedAt
+) {}

--- a/src/main/java/com/example/auction/domain/user/entity/User.java
+++ b/src/main/java/com/example/auction/domain/user/entity/User.java
@@ -29,6 +29,7 @@ public class User extends DeletableEntity {
     @Column(nullable = false)
     private UserRole role;
 
+    @Column(precision = 2, scale = 1)
     private BigDecimal rating;
 
     public static User of(String email, String encodedPassword, UserRole role) {

--- a/src/main/java/com/example/auction/domain/user/entity/User.java
+++ b/src/main/java/com/example/auction/domain/user/entity/User.java
@@ -40,4 +40,8 @@ public class User extends DeletableEntity {
 
         return user;
     }
+
+    public void changePassword(String encodedNewPassword) {
+        this.password = encodedNewPassword;
+    }
 }

--- a/src/main/java/com/example/auction/domain/user/exception/UserErrorEnum.java
+++ b/src/main/java/com/example/auction/domain/user/exception/UserErrorEnum.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorEnum implements ErrorEnumInterface {
 
     // 유저 관련
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다"),
+    HAS_ACTIVE_AUCTION(HttpStatus.CONFLICT, "진행 중인 경매가 있어 탈퇴할 수 없습니다."),
+    HAS_ACTIVE_BID(HttpStatus.CONFLICT, "진행 중인 입찰이 있어 탈퇴할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/auction/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/auction/domain/user/repository/UserRepository.java
@@ -8,5 +8,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
-    Optional<User> findByEmail(String email);
+    Optional<User> findByIdAndDeletedFalse(Long userId);
+
+    Optional<User> findByEmailAndDeletedFalse(String email);
 }

--- a/src/main/java/com/example/auction/domain/user/service/UserService.java
+++ b/src/main/java/com/example/auction/domain/user/service/UserService.java
@@ -1,12 +1,30 @@
 package com.example.auction.domain.user.service;
 
+import com.example.auction.common.exception.ServiceErrorException;
+import com.example.auction.domain.user.dto.UserGetResponse;
+import com.example.auction.domain.user.entity.User;
+import com.example.auction.domain.user.exception.UserErrorEnum;
 import com.example.auction.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public UserGetResponse myPage(Long userId) {
+        User user = userRepository.findByIdAndDeletedFalse(userId).orElseThrow(
+                () -> new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND));
+
+        return new UserGetResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getRating(),
+                user.getRole()
+        );
+    }
 }

--- a/src/main/java/com/example/auction/domain/user/service/UserService.java
+++ b/src/main/java/com/example/auction/domain/user/service/UserService.java
@@ -1,11 +1,14 @@
 package com.example.auction.domain.user.service;
 
 import com.example.auction.common.exception.ServiceErrorException;
+import com.example.auction.domain.auth.exception.AuthErrorEnum;
+import com.example.auction.domain.user.dto.UserChangePasswordRequest;
 import com.example.auction.domain.user.dto.UserGetResponse;
 import com.example.auction.domain.user.entity.User;
 import com.example.auction.domain.user.exception.UserErrorEnum;
 import com.example.auction.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     public UserGetResponse myPage(Long userId) {
@@ -26,5 +30,22 @@ public class UserService {
                 user.getRating(),
                 user.getRole()
         );
+    }
+
+    @Transactional
+    public void changePassword(Long userId, UserChangePasswordRequest request) {
+        User user = userRepository.findByIdAndDeletedFalse(userId).orElseThrow(
+                () -> new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND));
+
+        if (request.newPassword().equals(request.oldPassword())) {
+            throw new ServiceErrorException(AuthErrorEnum.SAME_AS_OLD_PASSWORD);
+        }
+
+        if (!passwordEncoder.matches(request.oldPassword(), user.getPassword())) {
+            throw new ServiceErrorException(AuthErrorEnum.INVALID_PASSWORD);
+        }
+
+        String encodedNewPassword = passwordEncoder.encode(request.newPassword());
+        user.changePassword(encodedNewPassword);
     }
 }

--- a/src/main/java/com/example/auction/domain/user/service/UserService.java
+++ b/src/main/java/com/example/auction/domain/user/service/UserService.java
@@ -1,0 +1,12 @@
+package com.example.auction.domain.user.service;
+
+import com.example.auction.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+}

--- a/src/main/java/com/example/auction/domain/user/service/UserService.java
+++ b/src/main/java/com/example/auction/domain/user/service/UserService.java
@@ -1,9 +1,14 @@
 package com.example.auction.domain.user.service;
 
 import com.example.auction.common.exception.ServiceErrorException;
+import com.example.auction.domain.auction.enums.AuctionStatus;
+import com.example.auction.domain.auction.repository.AuctionRepository;
 import com.example.auction.domain.auth.exception.AuthErrorEnum;
+import com.example.auction.domain.bid.enums.BidAuctionStatus;
+import com.example.auction.domain.bid.repository.BidRepository;
 import com.example.auction.domain.user.dto.UserChangePasswordRequest;
 import com.example.auction.domain.user.dto.UserGetResponse;
+import com.example.auction.domain.user.dto.UserWithdrawResponse;
 import com.example.auction.domain.user.entity.User;
 import com.example.auction.domain.user.exception.UserErrorEnum;
 import com.example.auction.domain.user.repository.UserRepository;
@@ -12,12 +17,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuctionRepository auctionRepository;
+    private final BidRepository bidRepository;
 
     @Transactional(readOnly = true)
     public UserGetResponse myPage(Long userId) {
@@ -47,5 +56,29 @@ public class UserService {
 
         String encodedNewPassword = passwordEncoder.encode(request.newPassword());
         user.changePassword(encodedNewPassword);
+    }
+
+    @Transactional
+    public UserWithdrawResponse withdraw(Long userId) {
+        User user = userRepository.findByIdAndDeletedFalse(userId).orElseThrow(
+                () -> new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND));
+
+        if (auctionRepository.existsByUserIdAndStatusIn(userId, List.of(AuctionStatus.READY, AuctionStatus.ACTIVE))) {
+            throw new ServiceErrorException(UserErrorEnum.HAS_ACTIVE_AUCTION);
+        }
+
+        if (bidRepository.existsByUserIdAndStatus(userId, BidAuctionStatus.ACTIVE)) {
+            throw new ServiceErrorException(UserErrorEnum.HAS_ACTIVE_BID);
+        }
+
+        user.delete();
+
+        return new UserWithdrawResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getRole(),
+                user.getCreatedAt(),
+                user.getDeletedAt()
+        );
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
### 마이페이지 조회 
- 탈퇴 유저 조회 차단 (`findByIdAndDeletedFalse`)

### 비밀번호 변경
- 새 비밀번호가 기존과 동일한 경우 예외 처리
- 기존 비밀번호 불일치 예외 처리

### 회원 탈퇴
- 진행 예정/진행 중인 경매(`READY`, `ACTIVE`) 구매자인 경우 탈퇴 방지
- 진행 중인 경매의 입찰자(`BidAuctionStatus.ACTIVE`)인 경우 탈퇴 방지
- 소프트 딜리트 처리 (`deleted = true`, `deletedAt` 업데이트)


## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항
탈퇴 후 동일 이메일 재가입 불가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필 조회 API 추가
  * 비밀번호 변경 API 추가(기존 비밀번호 불일치·동일 여부 검증, 새 비밀번호 최소 8자)
  * 계정 탈퇴 API 추가(탈퇴 성공 시 계정 정보 및 삭제 시각 반환)

* **버그 수정**
  * 삭제된 계정은 로그인 및 토큰 갱신 시 접근 불가하도록 처리
  * 진행 중인 경매/입찰이 있을 경우 계정 탈퇴 차단
<!-- end of auto-generated comment: release notes by coderabbit.ai -->