### PR TITLE
[FIX] AI SSE 이벤트 타입 분리 및 채팅방 권한 검증 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ application-local.yml
 
 .claude/
 CLAUDE.md
+
+### local docs ###
+docs/

--- a/src/main/java/com/example/auction/domain/ai/enums/SseEventType.java
+++ b/src/main/java/com/example/auction/domain/ai/enums/SseEventType.java
@@ -3,5 +3,6 @@ package com.example.auction.domain.ai.enums;
 public enum SseEventType {
     TOKEN,
     TOPIC,
+    ERROR,
     DONE
 }

--- a/src/main/java/com/example/auction/domain/ai/service/AiService.java
+++ b/src/main/java/com/example/auction/domain/ai/service/AiService.java
@@ -2,6 +2,7 @@ package com.example.auction.domain.ai.service;
 
 import com.example.auction.common.exception.ServiceErrorException;
 import com.example.auction.domain.ai.enums.SseEventType;
+import com.example.auction.domain.ai.exception.AiErrorEnum;
 import java.time.Duration;
 import com.example.auction.domain.chat.entity.ChatMessage;
 import com.example.auction.domain.chat.entity.ChatRoom;
@@ -26,9 +27,13 @@ public class AiService {
     private final ChatRoomRepository chatRoomRepository;
 
     public Flux<ServerSentEvent<String>> streamMessage(Long roomId, Long userId, String content) {
-        // 1. 채팅방 소유자 검증
-        ChatRoom chatRoom = chatRoomRepository.findByIdAndUserId(roomId, userId)
-                .orElseThrow(() -> new ServiceErrorException(ChatErrorEnum.CHAT_ROOM_FORBIDDEN));
+        // 1. 채팅방 존재 확인 + 소유자 검증
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ServiceErrorException(ChatErrorEnum.CHAT_ROOM_NOT_FOUND));
+
+        if (!chatRoom.getUserId().equals(userId)) {
+            throw new ServiceErrorException(ChatErrorEnum.CHAT_ROOM_FORBIDDEN);
+        }
 
         // 2. 유저 메시지 저장
         chatMessageRepository.save(ChatMessage.of(roomId, content, MessageRole.USER));
@@ -74,7 +79,7 @@ public class AiService {
                         .build()
         );
 
-        // 6. Fallback — CLAUDE.md: AI 장애 시 안내 메시지
+        // 6. Fallback — AI 장애 시 ERROR 이벤트로 오류 안내 후 DONE으로 스트림 종료
         return tokenStream
                 .concatWith(topicStream)
                 .concatWith(doneEvent)
@@ -82,8 +87,12 @@ public class AiService {
                     log.error("[AiService] 스트리밍 오류: {}", e.getMessage());
                     return Flux.just(
                             ServerSentEvent.<String>builder()
+                                    .event(SseEventType.ERROR.name())
+                                    .data(AiErrorEnum.AI_SERVICE_UNAVAILABLE.getMessage())
+                                    .build(),
+                            ServerSentEvent.<String>builder()
                                     .event(SseEventType.DONE.name())
-                                    .data("AI 서비스가 일시적으로 중단되었습니다")
+                                    .data("")
                                     .build()
                     );
                 });

--- a/src/main/java/com/example/auction/domain/chat/dto/ChatMessageListResponse.java
+++ b/src/main/java/com/example/auction/domain/chat/dto/ChatMessageListResponse.java
@@ -7,7 +7,7 @@ public record ChatMessageListResponse(
         Long nextCursor  // 다음 페이지 커서 (null이면 마지막 페이지)
 ) {
     public static ChatMessageListResponse of(List<ChatMessageResponse> messages, int size) {
-        // 요청한 size만큼 왔으면 다음 페이지 존재 — 마지막 메시지 id를 커서로
+        // 요청한 size만큼 왔으면 다음 페이지 존재 — 가장 오래된 메시지 id를 커서로 (id < cursor 조건으로 더 오래된 메시지 조회)
         boolean hasNext = messages.size() == size;
         Long nextCursor = hasNext ? messages.get(0).id() : null;
         return new ChatMessageListResponse(messages, nextCursor);


### PR DESCRIPTION
## 📝 작업 내용
- SSE 이벤트 타입 분리 (SseEventType, AiService)
   - 기존에 AI 장애 시 DONE 이벤트에 오류 메시지를 담아 전송하던 방식을 ERROR → DONE 순서로 분리.
 클라이언트가 정상 종료와 오류 상황을 이벤트 타입으로 명확히 구분 가능.
 AiErrorEnum 메시지를 참조하도록 변경해 하드코딩 제거.

- 채팅방 권한 검증 개선 (AiService)
    - 기존 findByIdAndUserId 단일 쿼리는 방이 없는 경우와 권한이 없는 경우
  모두 403을 반환하는 문제가 있었음.
  findById로 존재 여부를 먼저 확인(404)하고 userId 비교로 권한을 검증(403)하도록 개선.

## 🔗 관련 이슈 (Related Issues)

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [ ] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 스트리밍 중 서비스 오류 발생 시 사용자에게 더 명확한 에러 메시지 제공
  * 채팅방 접근 권한 검증 및 오류 응답 로직 개선

* **개선사항**
  * 메시지 목록 페이지네이션 커서 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->