### PR TITLE
[FEAT] 경매 조회에 간단한 caching 적용

### DIFF
--- a/src/main/java/com/example/auction/common/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/auction/common/config/RedisCacheConfig.java
@@ -42,9 +42,9 @@ public class RedisCacheConfig {
         // 캐시별 설정 (검색)
         Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
 
-        cacheConfigs.put("auctionSearch", defaultConfig.entryTtl(Duration.ofMinutes(10)));
+        cacheConfigs.put("getManyAuctionsPublic", defaultConfig.entryTtl(Duration.ofMinutes(10)));
 
-        cacheConfigs.put("auctionGetOne", defaultConfig.entryTtl(Duration.ofMinutes(10)));
+        cacheConfigs.put("getAuction", defaultConfig.entryTtl(Duration.ofMinutes(10)));
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig)

--- a/src/main/java/com/example/auction/common/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/auction/common/config/RedisCacheConfig.java
@@ -44,6 +44,8 @@ public class RedisCacheConfig {
 
         cacheConfigs.put("auctionSearch", defaultConfig.entryTtl(Duration.ofMinutes(10)));
 
+        cacheConfigs.put("auctionGetOne", defaultConfig.entryTtl(Duration.ofMinutes(10)));
+
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig)
                 .withInitialCacheConfigurations(cacheConfigs)

--- a/src/main/java/com/example/auction/domain/auction/dto/AuctionSearchCondition.java
+++ b/src/main/java/com/example/auction/domain/auction/dto/AuctionSearchCondition.java
@@ -23,7 +23,7 @@ public class AuctionSearchCondition {
     private @Nullable String keyword;
 
     @PositiveOrZero(message = "최소 금액은 0 이상이어야 합니다")
-    private BigDecimal maxPriceMin = BigDecimal.ZERO;
+    private @Nullable BigDecimal maxPriceMin;
     @Positive(message = "최대 금액은 0보다 커야합니다")
     private @Nullable BigDecimal maxPriceMax;
 

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionCacheService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionCacheService.java
@@ -1,0 +1,69 @@
+package com.example.auction.domain.auction.service;
+
+import java.math.BigDecimal;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.example.auction.domain.auction.dto.AuctionSearchCondition;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionCacheService {
+
+    public boolean shouldCacheGetManyAuctionsPublic(
+            AuctionSearchCondition condition
+    ) {
+        // 검색 키워드가 있을 경우 cache를 하는 것이 의미 없으므로 skip
+        if (condition.getKeyword() != null) {
+            return false;
+        }
+
+        // 만약에 가격의 범위를 포함해 검색한다면 skip
+        if (!(
+                condition.getMaxPriceMin().compareTo(BigDecimal.ZERO) == 0 &&
+                condition.getMaxPriceMax() == null
+        )) {
+            return false;
+        }
+
+        // 만약에 페이지가 10 페이지를 넘어갔다면 skip
+        if (condition.getPage() >= 9) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public String getManyAuctionsPublicCacheKey(
+            AuctionSearchCondition condition
+    ) {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("status=[");
+        if (condition.getStatus() != null) {
+            String statusKey = condition.getStatus()
+                .stream().sorted().map(Enum::name).collect(Collectors.joining(","));
+            builder.append(statusKey);
+        }
+        builder.append("]");
+
+        builder.append("category=[");
+        if (condition.getCategory() != null) {
+            builder.append(condition.getCategory());
+        }
+        builder.append("]");
+
+        builder.append("page=[");
+        builder.append(condition.getPage());
+        builder.append("]");
+
+        builder.append("pageSize=[");
+        builder.append(condition.getPageSize());
+        builder.append("]");
+
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionCacheService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionCacheService.java
@@ -22,10 +22,7 @@ public class AuctionCacheService {
         }
 
         // 만약에 가격의 범위를 포함해 검색한다면 skip
-        if (!(
-                condition.getMaxPriceMin().compareTo(BigDecimal.ZERO) == 0 &&
-                condition.getMaxPriceMax() == null
-        )) {
+        if (!(condition.getMaxPriceMin() == null && condition.getMaxPriceMax() == null)) {
             return false;
         }
 

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
@@ -1,6 +1,7 @@
 package com.example.auction.domain.auction.service;
 
 import org.jspecify.annotations.NonNull;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -32,7 +33,7 @@ public class AuctionService {
 
     @Transactional(readOnly = true)
     @Cacheable(
-        cacheNames =  {"auctionGetOne"},
+        cacheNames =  {"getAuction"},
         key = "#auctionId"
     )
     public GetAuctionResponse getAuction(Long auctionId) {
@@ -44,6 +45,11 @@ public class AuctionService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(
+        cacheNames = {"getManyAuctionsPublic"},
+        key = "@auctionCacheService.getManyAuctionsPublicCacheKey(#condition)",
+        condition = "@auctionCacheService.shouldCacheGetManyAuctionsPublic(#condition)"
+    )
     public PageResponse<GetManyAuctionsResponse> getManyAuctionsPublic (
             AuctionSearchCondition condition
     ) {
@@ -91,8 +97,12 @@ public class AuctionService {
 
     @Transactional()
     @CachePut(
-        cacheNames = {"auctionGetOne"},
+        cacheNames = {"getAuction"},
         key = "#result.getId()"
+    )
+    @CacheEvict(
+        cacheNames = {"getManyAuctionsPublic"},
+        allEntries = true
     )
     public GetAuctionResponse createAuction(
             CustomUserDetails userDetails,

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
@@ -1,6 +1,8 @@
 package com.example.auction.domain.auction.service;
 
 import org.jspecify.annotations.NonNull;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +31,10 @@ public class AuctionService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
+    @Cacheable(
+        cacheNames =  {"auctionGetOne"},
+        key = "#auctionId"
+    )
     public GetAuctionResponse getAuction(Long auctionId) {
         Auction auction = auctionRepository.findById(auctionId).orElseThrow(
                 () -> new ServiceErrorException(AuctionErrorEnum.AUCTION_NOT_FOUND)
@@ -84,6 +90,10 @@ public class AuctionService {
     }
 
     @Transactional()
+    @CachePut(
+        cacheNames = {"auctionGetOne"},
+        key = "#result.getId()"
+    )
     public GetAuctionResponse createAuction(
             CustomUserDetails userDetails,
             CreateAuctionRequest req

--- a/src/main/java/com/example/auction/domain/auction/util/AuctionUtil.java
+++ b/src/main/java/com/example/auction/domain/auction/util/AuctionUtil.java
@@ -1,6 +1,8 @@
 package com.example.auction.domain.auction.util;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 
 import com.example.auction.common.exception.ServiceErrorException;
 import com.example.auction.domain.auction.dto.AuctionSearchCondition;

--- a/src/main/java/com/example/auction/domain/auction/util/AuctionUtil.java
+++ b/src/main/java/com/example/auction/domain/auction/util/AuctionUtil.java
@@ -17,6 +17,7 @@ public class AuctionUtil {
     ) {
         // 검색 조건중 최소금액이 최대 금액 보다 클경우 에러를 던지기
         if (
+                condition.getMaxPriceMin() != null &&
                 condition.getMaxPriceMax() != null &&
                 condition.getMaxPriceMax().compareTo(condition.getMaxPriceMin()) < 0
         ) {


### PR DESCRIPTION
## 📝 작업 내용
- 경매 단건 조회에 caching을 구현했습니다.
- public user들을 향한 경매 다건 조회에 caching을 구현했습니다.

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항
일단 포스트맨으로 간단하게 DB쪽으로 조회가 안가는지만 테스트를 했습니다.

실제 성능 개선 보다는 앞으로 caching을 어떻게 구현할지 대충 방향을 정하기 위한 PR입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 경매 단건 조회와 공개 리스트에 캐시 기능을 추가했습니다.
* **Improvements**
  * 경매 생성 시 목록 캐시를 자동으로 갱신하고 단건 캐시를 최신화합니다.
  * 검색 조건의 일부 필터(최대값 최소값)를 선택적으로 비워 처리할 수 있도록 변경했습니다.
* **Bug Fixes**
  * 검색 조건 검증 시 null 참조를 방지하도록 안정성 검사를 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->