### PR TITLE
[FEAT] 경매 취소 구현

### DIFF
--- a/src/main/java/com/example/auction/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/example/auction/domain/auction/controller/AuctionController.java
@@ -79,4 +79,13 @@ public class AuctionController {
                         res
                 ));
     }
+
+    @DeleteMapping("/api/auctions/{auctionId}")
+    public ResponseEntity<Void> cancelAuction(
+            @PathVariable Long auctionId,
+            @AuthenticationPrincipal CustomUserDetails details
+    ) {
+        auctionService.cancelAuction(auctionId, details);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/example/auction/domain/auction/exception/AuctionErrorEnum.java
+++ b/src/main/java/com/example/auction/domain/auction/exception/AuctionErrorEnum.java
@@ -13,6 +13,20 @@ public enum AuctionErrorEnum implements ErrorEnumInterface {
             "경매를 찾을 수 없습니다"
     ),
 
+    AUCITON_STATUS_NOT_CACELLABLE(
+            HttpStatus.CONFLICT,
+            "경매를 취소할 수 있는 상태가 아닙니다"
+    ),
+    AUCITON_FORBIDDEN_FROM_CANCEL(
+            HttpStatus.FORBIDDEN,
+            "경매를 취소 할 수 있는 권한이 없습니다"
+    ),
+    AUCTION_TOO_LATE_TO_CANCEL(
+            HttpStatus.CONFLICT,
+            "경매를 취소하기에 너무 늦었습니다"
+    ),
+
+
     AUCTION_SEARCH_FORBIDDEN_STATUS_FILTER(
             HttpStatus.BAD_REQUEST, 
             "취소된 경매는 전체조회에서 볼 수 없습니다"

--- a/src/main/java/com/example/auction/domain/auction/exception/AuctionErrorEnum.java
+++ b/src/main/java/com/example/auction/domain/auction/exception/AuctionErrorEnum.java
@@ -13,13 +13,13 @@ public enum AuctionErrorEnum implements ErrorEnumInterface {
             "경매를 찾을 수 없습니다"
     ),
 
-    AUCITON_STATUS_NOT_CACELLABLE(
+    AUCTION_STATUS_NOT_CANCELLABLE(
             HttpStatus.CONFLICT,
             "경매를 취소할 수 있는 상태가 아닙니다"
     ),
-    AUCITON_FORBIDDEN_FROM_CANCEL(
+    AUCTION_FORBIDDEN_FROM_CANCEL(
             HttpStatus.FORBIDDEN,
-            "경매를 취소 할 수 있는 권한이 없습니다"
+            "경매를 취소할 수 있는 권한이 없습니다"
     ),
     AUCTION_TOO_LATE_TO_CANCEL(
             HttpStatus.CONFLICT,

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
@@ -174,7 +174,7 @@ public class AuctionService {
 
         // 경매 주인이 아니라면 에러를 던지기
         if (!auction.getUserId().equals(details.getUserId())) {
-            throw new ServiceErrorException(AuctionErrorEnum.AUCITON_FORBIDDEN_FROM_CANCEL);
+            throw new ServiceErrorException(AuctionErrorEnum.AUCTION_FORBIDDEN_FROM_CANCEL);
         }
 
         // 경매가 이미 취소되어 있다면 noop
@@ -184,7 +184,7 @@ public class AuctionService {
 
         // 경매가 준비 상태가 아니라면 에러를 던지기
         if (!auction.getStatus().equals(AuctionStatus.READY)) {
-            throw new ServiceErrorException(AuctionErrorEnum.AUCITON_STATUS_NOT_CACELLABLE);
+            throw new ServiceErrorException(AuctionErrorEnum.AUCTION_STATUS_NOT_CANCELLABLE);
         }
 
         // 경매를 취소하기 너무 늦었다면 에러를 던지기

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
@@ -1,9 +1,13 @@
 package com.example.auction.domain.auction.service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+
 import org.jspecify.annotations.NonNull;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -108,6 +112,7 @@ public class AuctionService {
             CustomUserDetails userDetails,
             CreateAuctionRequest req
     ) {
+        // 경매 생성은 중요한 작업이기 때문에 JWT만을 믿지 않고 DB에 유저가 있는지 확인
         userRepository.findById(userDetails.getUserId()).orElseThrow(()->
             new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND)
         );
@@ -127,5 +132,70 @@ public class AuctionService {
         auction = auctionRepository.saveAndFlush(auction);
 
         return GetAuctionResponse.from(auction);
+    }
+
+    @Transactional()
+    @Caching(
+        evict = {
+            @CacheEvict(
+                cacheNames = {"getManyAuctionsPublic"},
+                allEntries = true
+            ),
+            @CacheEvict(
+                cacheNames = {"getAuction"},
+                key = "#auctionId"
+            ),
+        }
+    )
+    public void cancelAuction(
+            Long auctionId,
+            CustomUserDetails details
+    ) {
+        // 경매를 취소 할 때 비관적 락을 걸지 않고 select를 합니다.
+        //
+        // 일단 저희가 경매 시작 직전에 취소를 막기 때문에 동시성 문제가 발생할 일이 없고
+        // 또 여러 사람이 같은 경매를 취소 할 일이 없기 때문입니다. 
+        //
+        // (현재 경매는 본인만 취소가 가능합니다.
+        // 그리고 설령 저희가 나중에 관리자가 남의 경매를 취소하게 변경하더라도 
+        // 경매자와 고객이 동시에 취소 할려고
+        // 해서 동시성 문제가 발생 할 거라 생각 하지는 않습니다)
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 경매 취소는 중요한 작업이기 때문에 JWT만을 믿지 않고 DB에 유저가 있는지 확인
+        userRepository.findById(details.getUserId()).orElseThrow(()->
+            new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND)
+        );
+
+        Auction auction = auctionRepository.findById(auctionId).orElseThrow(
+                () -> new ServiceErrorException(AuctionErrorEnum.AUCTION_NOT_FOUND)
+        );
+
+        // 경매 주인이 아니라면 에러를 던지기
+        if (!auction.getUserId().equals(details.getUserId())) {
+            throw new ServiceErrorException(AuctionErrorEnum.AUCITON_FORBIDDEN_FROM_CANCEL);
+        }
+
+        // 경매가 이미 취소되어 있다면 noop
+        if (auction.getStatus().equals(AuctionStatus.CANCELLED)) {
+            return;
+        }
+
+        // 경매가 준비 상태가 아니라면 에러를 던지기
+        if (!auction.getStatus().equals(AuctionStatus.READY)) {
+            throw new ServiceErrorException(AuctionErrorEnum.AUCITON_STATUS_NOT_CACELLABLE);
+        }
+
+        // 경매를 취소하기 너무 늦었다면 에러를 던지기
+        LocalDateTime canCancelAfter = auction.getStartedAt().minus(Duration.ofMinutes(10));
+
+        if (!now.isBefore(canCancelAfter)) {
+            throw new ServiceErrorException(AuctionErrorEnum.AUCTION_TOO_LATE_TO_CANCEL);
+        }
+
+        auction.cancel();
+
+        auctionRepository.saveAndFlush(auction);
     }
 }

--- a/src/test/java/com/example/auction/domain/auction/service/AuctionServiceCancelTest.java
+++ b/src/test/java/com/example/auction/domain/auction/service/AuctionServiceCancelTest.java
@@ -1,0 +1,203 @@
+package com.example.auction.domain.auction.service;
+
+import com.example.auction.common.config.security.CustomUserDetails;
+import com.example.auction.common.exception.ServiceErrorException;
+import com.example.auction.domain.auction.entity.Auction;
+import com.example.auction.domain.auction.enums.AuctionProductCategory;
+import com.example.auction.domain.auction.enums.AuctionStatus;
+import com.example.auction.domain.auction.repository.AuctionRepository;
+import com.example.auction.domain.user.entity.User;
+import com.example.auction.domain.user.enums.UserRole;
+import com.example.auction.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuctionServiceCancelTest {
+    @InjectMocks
+    private AuctionService auctionService;
+
+    @Mock
+    private AuctionRepository auctionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("기본적인 경매 취소")
+    void canCancelRegularAuction() {
+        // GIVEN
+        User user = createMockUser();
+
+        Auction auction = Auction.of(
+                user.getId(),
+                "test auction description",
+                BigDecimal.valueOf(1000),
+                "test auction name",
+                LocalDateTime.now().plusDays(30),
+                LocalDateTime.now().plusDays(40),
+                AuctionProductCategory.BOOKS
+        );
+        ReflectionTestUtils.setField(auction, "id", 1L);
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
+
+        // WHEN & THEN (취소를 한 후 에러가 발생 안하는지만 확인)
+        auctionService.cancelAuction(
+            auction.getId(),
+            new CustomUserDetails(user.getId(), user.getRole().toString())
+        );
+    }
+
+    @Test
+    @DisplayName("취소된 경매를 다시 취소 해도 에러가 아님")
+    void cancelIdempotency() {
+        // GIVEN
+        User user = createMockUser();
+
+        Auction auction = Auction.of(
+                user.getId(),
+                "test auction description",
+                BigDecimal.valueOf(1000),
+                "test auction name",
+                LocalDateTime.now().plusDays(30),
+                LocalDateTime.now().plusDays(40),
+                AuctionProductCategory.BOOKS
+        );
+        ReflectionTestUtils.setField(auction, "id", 1L);
+        ReflectionTestUtils.setField(auction, "status", AuctionStatus.CANCELLED);
+
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
+
+        // WHEN & THEN (취소를 한 후 에러가 발생 안하는지만 확인)
+        auctionService.cancelAuction(
+                auction.getId(),
+                new CustomUserDetails(user.getId(), user.getRole().toString())
+        );
+    }
+
+    @Test
+    @DisplayName("경매 시작 직전에는 경매 취소를 할 수 없다")
+    void forbidLateCancel() {
+        // GIVEN
+        User user = createMockUser();
+
+        Auction auction = Auction.of(
+                user.getId(),
+                "test auction description",
+                BigDecimal.valueOf(1000),
+                "test auction name",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusSeconds(1),
+                AuctionProductCategory.BOOKS
+        );
+        ReflectionTestUtils.setField(auction, "id", 1L);
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
+
+        // WHEN & THEN 
+        assertThrows(ServiceErrorException.class, () -> {
+            auctionService.cancelAuction(
+                    auction.getId(),
+                    new CustomUserDetails(user.getId(), user.getRole().toString())
+            );
+        });
+    }
+
+    @Test
+    @DisplayName("자기 자신의 경매만 취소가 가능하다")
+    void canOnlyCancelYourOwn() {
+        // NOTE: 지금 현재로서는 자기 자신의 경매만 취소가 가능합니다.
+        //  하지만 나중에 관리자도 남의 경매를 취소가 가능하게 한다면 이를 반영해야 할 듯 합니다.
+
+        // GIVEN
+        User user = createMockUser();
+
+        Auction auction = Auction.of(
+                69L,
+                "test auction description",
+                BigDecimal.valueOf(1000),
+                "test auction name",
+                LocalDateTime.now().plusDays(30),
+                LocalDateTime.now().plusDays(40),
+                AuctionProductCategory.BOOKS
+        );
+        ReflectionTestUtils.setField(auction, "id", 1L);
+
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
+
+        // WHEN & THEN
+        assertThrows(ServiceErrorException.class, () -> {
+            auctionService.cancelAuction(
+                    auction.getId(),
+                    new CustomUserDetails(user.getId(), user.getRole().toString())
+            );
+        });
+    }
+
+    @ParameterizedTest()
+    @MethodSource("getThrowOnNonCancellableStatusSources")
+    @DisplayName("준비, 취소 된 경매 이외에 경매는 취소 할 수 없다")
+    void throwOnNonCancellableStatus(AuctionStatus status) {
+        // GIVEN
+        User user = createMockUser();
+
+        Auction auction = Auction.of(
+                user.getId(),
+                "test auction description",
+                BigDecimal.valueOf(1000),
+                "test auction name",
+                LocalDateTime.now().plusDays(30),
+                LocalDateTime.now().plusDays(40),
+                AuctionProductCategory.BOOKS
+        );
+        ReflectionTestUtils.setField(auction, "id", 1L);
+        ReflectionTestUtils.setField(auction, "status", status);
+
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
+
+        // WHEN & THEN
+        if (status == AuctionStatus.READY || status == AuctionStatus.CANCELLED) {
+            auctionService.cancelAuction(
+                    auction.getId(),
+                    new CustomUserDetails(user.getId(), user.getRole().toString())
+            );
+        }else {
+            assertThrows(ServiceErrorException.class, () -> {
+                auctionService.cancelAuction(
+                        auction.getId(),
+                        new CustomUserDetails(user.getId(), user.getRole().toString())
+                );
+            });
+        }
+    }
+
+    private static Stream<Arguments> getThrowOnNonCancellableStatusSources() {
+        return Arrays.stream(AuctionStatus.values()).map(Arguments::of);
+    }
+
+    private User createMockUser() {
+        User user = User.of("test@test.com", "encodedPassword", UserRole.USER);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+        return user;
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 경매 취소를 구현하였습니다.
- 이에 대한 테스트를 작성하였습니다.

## 🔗 관련 이슈 (Related Issues)
Closes #

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항

1. 일단 자기 자신의 경매 만을 취소 할 수 있도록 구현하였습니다.
나중에 관리자는 타인의 경매를 취소 할 수 있게 허용한다면 수정해야 할 것입니다.

2. 통합 테스트는 작성하지 않았습니다.
이느 경매 service의 로직이 잘 작동할 경우 실제 환경에서도 잘 작동 할 거라 생각하기 때문입니다.

정말 문제가 생길 이유는 cache invalidation에서 일어날 거라 생각합니다.

이는 cache test를 작성하면서 따로 테스트 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 경매 취소 기능이 추가되었습니다. 경매 소유자는 경매 시작 10분 전까지 경매를 취소할 수 있습니다. 권한이 없거나 취소 불가능한 상태의 경매는 취소할 수 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->