### PR TITLE
[FEAT] spring actuator추가, AWS parameter store 지원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,12 @@ dependencies {
     //redisson
     implementation 'org.redisson:redisson:3.45.0'
 
+    // monitoring and aws deployment dependencies
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:4.0.0')
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -4,32 +4,26 @@ services:
   spring:
     image: ${ECR_URI}
     container_name: auction-spring
+    restart: on-failure:5
     depends_on:
       redis:
         condition: service_healthy
     environment:
-      POSTGRES_URL: ${POSTGRES_URL}
-      POSTGRES_USERNAME: ${POSTGRES_USERNAME}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-
-      REDIS_HOST: ${REDIS_HOST}
-
       SPRING_PROFILES_ACTIVE: prod
-      # 만약을 위해서 있는 DDL_AUTO setting
-      # 물론 배포시에 create로 띄우면 안되긴 하지만
-      # 일단 저희가 고객 데이터가 없고 또 sql schema를 작성하지
-      # 않았으므로 편의를 위해서 setting을 넣었습니다.
-      # 
-      # TODO: 이거 빼기
-      SPRING_JPA_HIBERNATE_DDL_AUTO: ${SPRING_JPA_HIBERNATE_DDL_AUTO}
-
-      JWT_SECRET: ${JWT_SECRET}
     ports:
       - "8080:8080"
+
+    healthcheck:
+      test: "curl --fail --silent localhost:8080/actuator/health | grep UP || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   redis:
     image: redis:8.6.2
     container_name: auction-redis
+    restart: on-failure:5
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -14,3 +14,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  redis:
+    image: redis:8.6.2
+    container_name: auction-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+

--- a/src/main/java/com/example/auction/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/auction/common/config/security/SecurityConfig.java
@@ -45,6 +45,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET,"/api/reviews/{reviewId}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/actuator/health").permitAll() // spring actuator health check는 모두가 가능
+                        .requestMatchers("/actuator/**").hasRole("ADMIN") // 그외에 것은 관리자만 가능
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(endpoint -> endpoint

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    import: aws-parameterstore:/param/reverse-auction/prod/
+
   datasource:
     url: ${POSTGRES_URL}
     username: ${POSTGRES_USERNAME}
@@ -15,7 +18,26 @@ spring:
         format_sql: false
     defer-datasource-initialization: false
 
+  cloud:
+    # AWS 관련
+    aws:
+      # parameterstore 활성화
+      parameterstore:
+        enabled: true
+
   data:
     redis:
       host: ${REDIS_HOST:localhost}
       port: 6379
+
+# actuator 관련
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+
+  endpoint:
+    health:
+      show-details: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,13 @@ spring:
   application:
     name: auction
 
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiImageAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiModerationAutoConfiguration
+
   profiles:
     include: oauth
 
@@ -25,6 +32,27 @@ spring:
         api-key: ${OPENAI_API_KEY}
         options:
           model: text-embedding-3-small    # 텍스트 → 벡터 변환 전용 임베딩 모델 (RAG용)
+
+  cloud:
+    # AWS 관련
+    aws:
+      # 기본적으로 parameterstore는 비활성화
+      parameterstore:
+        enabled: false
+
+# actuator 관련
+# 일단은 ALB나 ASG 를 위해서 health end point를 열어둡니다.
+# 다른 정보들은 나중에 추가합시다.
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+
+  endpoint:
+    health:
+      show-details: never
 
 jwt:
   secret:


### PR DESCRIPTION
## 📝 작업 내용
spring actuator는 공개적으로는 health만 접근 할 수 있으며 다른
endpont들은 ADMIN으로 서만 접근 가능하게 설정했습니다.

이는 저희 서버를 관리해줄 다른 프로그램들이나 서비스들의 접근을 쉽게
하기 위해서 입니다.

그리고 AWS parameter 지원을 추가했습니다.

## 🔗 관련 이슈 (Related Issues)

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션에서 AWS 파라미터 스토어 통합 활성화
  * Spring Actuator(헬스) 노출 및 세부정보 제한 설정
  * 프로덕션 및 테스트 Docker 구성에 재시작 정책 및 헬스체크 강화
  * 테스트 환경에 Redis 캐시 서비스 추가
  * Actuator 엔드포인트 접근 제어로 헬스는 공개, 기타는 관리자 권한 요구
<!-- end of auto-generated comment: release notes by coderabbit.ai -->