### PR TITLE
[FEAT] 카테고리 목록 조회에 캐싱 적용

### DIFF
--- a/src/main/java/com/example/auction/common/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/auction/common/config/RedisCacheConfig.java
@@ -46,6 +46,8 @@ public class RedisCacheConfig {
 
         cacheConfigs.put("getAuction", defaultConfig.entryTtl(Duration.ofMinutes(10)));
 
+        cacheConfigs.put("getCategoryList", defaultConfig.entryTtl(Duration.ofHours(1)));
+
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig)
                 .withInitialCacheConfigurations(cacheConfigs)

--- a/src/main/java/com/example/auction/common/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/auction/common/config/RedisCacheConfig.java
@@ -51,6 +51,7 @@ public class RedisCacheConfig {
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig)
                 .withInitialCacheConfigurations(cacheConfigs)
+                .transactionAware()
                 .build();
     }
 }

--- a/src/main/java/com/example/auction/domain/category/service/CategoryService.java
+++ b/src/main/java/com/example/auction/domain/category/service/CategoryService.java
@@ -6,6 +6,8 @@ import com.example.auction.domain.category.entity.Category;
 import com.example.auction.domain.category.exception.CategoryErrorEnum;
 import com.example.auction.domain.category.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +25,7 @@ public class CategoryService {
     private static final int MAX_DEPTH = 2;
 
     @Transactional
+    @CacheEvict(cacheNames = "getCategoryList", key = "'all'")
     public CategoryCreateResponse createCategory(CategoryCreateRequest request) {
         Category category = request.parentId() == null ? rootCategory(request.name()) : childCategory(request.parentId(), request.name());
         categoryRepository.save(category);
@@ -36,6 +39,7 @@ public class CategoryService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = "getCategoryList", key = "'all'")
     public CategoryRenameResponse renameCategory(Long categoryId, CategoryRenameRequest request) {
         Category category = categoryRepository.findById(categoryId).orElseThrow(
                 () -> new ServiceErrorException(CategoryErrorEnum.CATEGORY_NOT_FOUND));
@@ -56,6 +60,7 @@ public class CategoryService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = "getCategoryList", key = "'all'")
     public CategoryMoveResponse moveCategory(Long categoryId, CategoryMoveRequest request) {
         Category category = categoryRepository.findById(categoryId).orElseThrow(
                 () -> new ServiceErrorException(CategoryErrorEnum.CATEGORY_NOT_FOUND));
@@ -99,6 +104,7 @@ public class CategoryService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = "getCategoryList", key = "'all'")
     public List<CategoryListGetResponse> getCategoryList() {
         List<Category> categoryList = categoryRepository.findAll();
 

--- a/src/test/java/com/example/auction/domain/category/service/CategoryServiceCacheTest.java
+++ b/src/test/java/com/example/auction/domain/category/service/CategoryServiceCacheTest.java
@@ -1,0 +1,150 @@
+package com.example.auction.domain.category.service;
+
+import com.example.auction.domain.category.dto.CategoryCreateRequest;
+import com.example.auction.domain.category.dto.CategoryMoveRequest;
+import com.example.auction.domain.category.dto.CategoryRenameRequest;
+import com.example.auction.domain.category.entity.Category;
+import com.example.auction.domain.category.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(classes = {CategoryService.class, CategoryServiceCacheTest.TestConfig.class})
+public class CategoryServiceCacheTest {
+
+    @MockitoBean
+    private CategoryRepository categoryRepository;
+
+    @MockitoBean
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @TestConfiguration
+    @EnableCaching
+    static class TestConfig {
+        @Bean
+        public CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("getCategoryList");
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        // @Transactional 처리용
+        given(transactionManager.getTransaction(any())).willReturn(mock(TransactionStatus.class));
+        cacheManager.getCache("getCategoryList").clear();
+    }
+
+
+    // ========================
+    // @Cacheable 검증
+    // ========================
+
+    @Test
+    @DisplayName("getCategoryList - 동일 호출 2번 시 repository는 1번만 호출")
+    void getCategoryList_cacheable() {
+        // given
+        Category root = Category.root("전자기기");
+        ReflectionTestUtils.setField(root, "id", 1L);
+        given(categoryRepository.findAll()).willReturn(List.of(root));
+
+        // when
+        categoryService.getCategoryList();
+        categoryService.getCategoryList(); // 캐시 히트
+
+        // then
+        verify(categoryRepository, times(1)).findAll();
+    }
+
+
+    // ========================
+    // @CacheEvict 검증
+    // ========================
+
+    @Test
+    @DisplayName("createCategory - 캐시 무효화 후 재조회 시 repository 재호출")
+    void createCategory_evictsCache() {
+        // given
+        Category root = Category.root("전자기기");
+        ReflectionTestUtils.setField(root, "id", 1L);
+        given(categoryRepository.findAll()).willReturn(List.of(root));
+        categoryService.getCategoryList();
+
+        // when
+        given(categoryRepository.existsByParentIdIsNullAndName("가구")).willReturn(false);
+        given(categoryRepository.save(any())).willAnswer(inv -> {
+            Category c = inv.getArgument(0);
+            ReflectionTestUtils.setField(c, "id", 2L);
+            return c;
+        });
+        categoryService.createCategory(new CategoryCreateRequest(null, "가구"));
+        categoryService.getCategoryList(); // 무효화 후 재조회
+
+        // then
+        verify(categoryRepository, times(2)).findAll();
+    }
+
+    @Test
+    @DisplayName("renameCategory - 캐시 무효화 후 재조회 시 repository 재호출")
+    void renameCategory_evictsCache() {
+        // given
+        Category root = Category.root("전자기기");
+        ReflectionTestUtils.setField(root, "id", 1L);
+        given(categoryRepository.findAll()).willReturn(List.of(root));
+        categoryService.getCategoryList();
+
+        // when
+        given(categoryRepository.findById(1L)).willReturn(Optional.of(root));
+        given(categoryRepository.existsByParentIdIsNullAndName("가전제품")).willReturn(false);
+        categoryService.renameCategory(1L, new CategoryRenameRequest("가전제품"));
+        categoryService.getCategoryList();
+
+        // then
+        verify(categoryRepository, times(2)).findAll();
+    }
+
+    @Test
+    @DisplayName("moveCategory - 캐시 무효화 후 재조회 시 repository 재호출")
+    void moveCategory_evictsCache() {
+        // given
+        Category root = Category.root("전자기기");
+        ReflectionTestUtils.setField(root, "id", 1L);
+        given(categoryRepository.findAll()).willReturn(List.of(root));
+        categoryService.getCategoryList();
+
+        // when
+        Category child = Category.child(1L, "스마트폰", 0);
+        ReflectionTestUtils.setField(child, "id", 2L);
+        given(categoryRepository.findById(2L)).willReturn(Optional.of(child));
+        given(categoryRepository.existsByParentIdIsNullAndName("스마트폰")).willReturn(false);
+        given(categoryRepository.findAllByParentId(2L)).willReturn(List.of());
+        categoryService.moveCategory(2L, new CategoryMoveRequest(null));
+        categoryService.getCategoryList();
+
+        // then
+        verify(categoryRepository, times(2)).findAll();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
### 카테고리 목록 조회 Redis 캐싱 적용
- `CategoryService.getCategoryList()`에 `@Cacheable` 적용
- `createCategory`, `renameCategory`, `moveCategory`에 `@CacheEvict` 적용
- `RedisCacheConfig`에 `getCategoryList` 캐시 설정 추가 (TTL 1시간)

### @Cacheable 및 @CacheEvict 동작 검증 테스트 추가
- `ConcurrentMapCacheManager`로 Redis 없이 캐시 동작 검증
- 동일 호출 2번 시 repository 1번만 호출되는지 확인
- create/rename/move 후 캐시 무효화 및 재조회 시 repository 재호출 확인

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **성능 개선**
  * 카테고리 목록 조회 성능이 대폭 향상되었습니다.
  * 조회 결과가 1시간 동안 자동으로 캐시 처리되어, 반복되는 사용자 요청 시 데이터베이스에 직접 접근하지 않고 캐시된 데이터에서 즉시 빠르게 응답합니다.
  * 카테고리를 추가, 이름 변경, 또는 이동하는 작업을 수행할 때 캐시가 자동으로 갱신되므로, 항상 최신의 정확한 정보를 유지하면서도 조회 성능 향상을 함께 누릴 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->