### PR TITLE
[FEAT] Redis Pub/Sub 기반 알림 이벤트 발행 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,11 +30,11 @@ jobs:
         id: vars
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      # Java 17 설치
-      - name: Setup Java 17
+      # Java 21 설치
+      - name: Setup Java 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'corretto'
 
       # Gradle 캐시

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
-          java-version: "17"
+          distribution: "corretto"
+          java-version: "21"
           cache: "gradle"
 
       - name: check if builds

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-al2023-headless
+FROM amazoncorretto:21-al2023-headless
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'auction'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,6 @@ dependencies {
     // Cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
 
-    // Kafka
-    implementation 'org.springframework.boot:spring-boot-starter-kafka'
-
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
@@ -59,7 +56,7 @@ dependencies {
     // Social Login
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-    //redisson
+    // redisson
     implementation 'org.redisson:redisson-spring-boot-starter:4.0.0'
 
     // actuator
@@ -82,7 +79,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,38 +29,6 @@ services:
       timeout: 5s
       retries: 5
 
-  kafka:
-    image: apache/kafka:4.0.2
-    container_name: auction-kafka
-    ports:
-      - "9092:9092"
-    environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-    healthcheck:
-      test: [ "CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list" ]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
-
-  kafka-ui:
-    image: provectuslabs/kafka-ui:latest
-    container_name: auction-kafka-ui
-    ports:
-      - "8999:8080"
-    environment:
-      KAFKA_CLUSTERS_0_NAME: local
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
-    depends_on:
-      kafka:
-        condition: service_healthy
-
   redis-insight:
     image: redis/redisinsight:latest
     container_name: auction-redis-insight
@@ -73,7 +41,21 @@ services:
   app:
     build: .
     container_name: auction-app
+    ports:
+      - "8080:8080"
     environment:
+      SPRING_PROFILES_ACTIVE: dev
+      POSTGRES_URL: ${POSTGRES_URL}
+      POSTGRES_USERNAME: ${POSTGRES_USERNAME}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      REDIS_HOST: ${REDIS_HOST}
+      JWT_SECRET: ${JWT_SECRET}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
+      NAVER_CLIENT_ID: ${NAVER_CLIENT_ID}
+      NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
     depends_on:
@@ -81,7 +63,23 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      kafka:
+
+  notification:
+    build: ../auction-notification
+    container_name: auction-notification
+    ports:
+      - "8081:8081"
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      POSTGRES_URL: ${POSTGRES_URL}
+      POSTGRES_USERNAME: ${POSTGRES_USERNAME}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      REDIS_HOST: ${REDIS_HOST}
+      JWT_SECRET: ${JWT_SECRET}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
 volumes:

--- a/src/main/java/com/example/auction/domain/bid/service/BidCommandProcessor.java
+++ b/src/main/java/com/example/auction/domain/bid/service/BidCommandProcessor.java
@@ -12,6 +12,9 @@ import com.example.auction.domain.bid.entity.Bid;
 import com.example.auction.domain.bid.enums.BidAuctionStatus;
 import com.example.auction.domain.bid.exceptions.BidErrorEnum;
 import com.example.auction.domain.bid.repository.BidRepository;
+import com.example.auction.domain.notification.dto.NotificationMessage;
+import com.example.auction.domain.notification.enums.NotificationType;
+import com.example.auction.domain.notification.publisher.NotificationMessagePublisher;
 import com.example.auction.domain.user.entity.User;
 import com.example.auction.domain.user.exception.UserErrorEnum;
 import com.example.auction.domain.user.repository.UserRepository;
@@ -34,6 +37,7 @@ public class BidCommandProcessor {
     private final BidRepository bidRepository;
     private final AuctionRepository auctionRepository;
     private final UserRepository userRepository;
+    private final NotificationMessagePublisher notificationMessagePublisher;
 
     // requires_new를 붙여야 메서드가 끝날 때 커밋이 확정되어서 커밋 -> 락해제 순서가 보장됨
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -74,6 +78,9 @@ public class BidCommandProcessor {
             throw new ServiceErrorException(BidErrorEnum.BID_PRICE_NOT_LOWER);
         }
 
+        // 기존 최저가 입찰 조회
+        Bid currentMin = bidRepository.findFirstByAuctionIdOrderByPriceAsc(auctionId).orElse(null);
+
         // 입찰 생성 및 저장
         Bid bid = Bid.of(
                 request.getDescription(),
@@ -85,7 +92,17 @@ public class BidCommandProcessor {
 
         log.info("[입찰] auctionId={}, userId={}, bidPrice={}", auctionId, userId, bidPrice);
 
-        // todo: 카프카 이벤트 발행
+        // 새 입찰 발생 알림
+        notificationMessagePublisher.publish(new NotificationMessage(
+                NotificationType.NEW_BID, auction.getUserId(), auctionId, auction.getItemName()
+        ));
+
+        // 최저가 갱신 알림
+        if (currentMinPrice != null && currentMin != null) {
+            notificationMessagePublisher.publish(new NotificationMessage(
+                    NotificationType.LOWEST_BID_UPDATED, currentMin.getUserId(), auctionId, auction.getItemName()
+            ));
+        }
 
         return BidResponse.of(savedBid);
     }

--- a/src/main/java/com/example/auction/domain/bid/service/BidCommandProcessor.java
+++ b/src/main/java/com/example/auction/domain/bid/service/BidCommandProcessor.java
@@ -23,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -92,17 +94,22 @@ public class BidCommandProcessor {
 
         log.info("[입찰] auctionId={}, userId={}, bidPrice={}", auctionId, userId, bidPrice);
 
-        // 새 입찰 발생 알림
-        notificationMessagePublisher.publish(new NotificationMessage(
-                NotificationType.NEW_BID, auction.getUserId(), auctionId, auction.getItemName()
-        ));
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                // 새 입찰 발생 알림
+                notificationMessagePublisher.publish(new NotificationMessage(
+                        NotificationType.NEW_BID, auction.getUserId(), auctionId, auction.getItemName()
+                ));
 
-        // 최저가 갱신 알림
-        if (currentMinPrice != null && currentMin != null) {
-            notificationMessagePublisher.publish(new NotificationMessage(
-                    NotificationType.LOWEST_BID_UPDATED, currentMin.getUserId(), auctionId, auction.getItemName()
-            ));
-        }
+                // 최저가 갱신 알림
+                if (currentMinPrice != null && currentMin != null) {
+                    notificationMessagePublisher.publish(new NotificationMessage(
+                            NotificationType.LOWEST_BID_UPDATED, currentMin.getUserId(), auctionId, auction.getItemName()
+                    ));
+                }
+            }
+        });
 
         return BidResponse.of(savedBid);
     }

--- a/src/main/java/com/example/auction/domain/notification/dto/NotificationMessage.java
+++ b/src/main/java/com/example/auction/domain/notification/dto/NotificationMessage.java
@@ -1,0 +1,10 @@
+package com.example.auction.domain.notification.dto;
+
+import com.example.auction.domain.notification.enums.NotificationType;
+
+public record NotificationMessage(
+        NotificationType type,
+        Long receiverId,
+        Long auctionId,
+        String itemName
+) {}

--- a/src/main/java/com/example/auction/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/auction/domain/notification/enums/NotificationType.java
@@ -1,0 +1,44 @@
+package com.example.auction.domain.notification.enums;
+
+import com.example.auction.domain.notification.dto.NotificationMessage;
+
+public enum NotificationType {
+    AUCTION_STARTED {
+        @Override
+        public String generateMessage(NotificationMessage message) {
+            return "'" + message.itemName() + "' 경매가 시작됐습니다.";
+        }
+    },
+    NEW_BID {
+        @Override
+        public String generateMessage(NotificationMessage message) {
+            return "'" + message.itemName() + "' 경매에 새 입찰이 들어왔습니다.";
+        }
+    },
+    LOWEST_BID_UPDATED {
+        @Override
+        public String generateMessage(NotificationMessage message) {
+            return "'" + message.itemName() + "' 경매에 더 낮은 입찰이 들어왔습니다. 재입찰을 고려해보세요.";
+        }
+    },
+    AUCTION_CLOSED_WIN {
+        @Override
+        public String generateMessage(NotificationMessage message) {
+            return "축하합니다! '" + message.itemName() + "' 경매에 낙찰됐습니다.";
+        }
+    },
+    AUCTION_CLOSED_BUYER {
+        @Override
+        public String generateMessage(NotificationMessage message) {
+            return "'" + message.itemName() + "' 경매의 낙찰자가 결정됐습니다.";
+        }
+    },
+    AUCTION_NO_BID {
+        @Override
+        public String generateMessage(NotificationMessage message) {
+            return "'" + message.itemName() + "' 경매가 입찰자 없이 종료됐습니다.";
+        }
+    };
+
+    public abstract String generateMessage(NotificationMessage message);
+}

--- a/src/main/java/com/example/auction/domain/notification/publisher/NotificationMessagePublisher.java
+++ b/src/main/java/com/example/auction/domain/notification/publisher/NotificationMessagePublisher.java
@@ -17,8 +17,9 @@ public class NotificationMessagePublisher {
     public void publish(NotificationMessage message) {
         try {
             redisTemplate.convertAndSend(CHANNEL, message);
-        } catch (Exception e) {
-            log.error("알림 메시지 발행 실패: {}", e.getMessage(), e);
+        } catch (RuntimeException e) {
+            log.error("알림 메시지 발행 실패: channel={}, type={}, receiverId={}",
+                    CHANNEL, message.type(), message.receiverId(), e);
         }
     }
 }

--- a/src/main/java/com/example/auction/domain/notification/publisher/NotificationMessagePublisher.java
+++ b/src/main/java/com/example/auction/domain/notification/publisher/NotificationMessagePublisher.java
@@ -1,0 +1,24 @@
+package com.example.auction.domain.notification.publisher;
+
+import com.example.auction.domain.notification.dto.NotificationMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationMessagePublisher {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String CHANNEL = "auction:notification";
+
+    public void publish(NotificationMessage message) {
+        try {
+            redisTemplate.convertAndSend(CHANNEL, message);
+        } catch (Exception e) {
+            log.error("알림 메시지 발행 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,9 +16,6 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: 6379
 
-  kafka:
-    bootstrap-servers: ${KAFKA_HOST:localhost}:9092
-
   ai:
     openai:
       chat:


### PR DESCRIPTION
## 📝 작업 내용
입찰 발생 시 auction-notification 서비스로 알림 이벤트를 발행하는 Redis Pub/Sub Publisher를 구현

 ### Kafka 제거                                                                                                                                                                                         
- Kafka 의존성 및 관련 설정 제거

### 도메인
- 알림 타입 enum 정의 (`NotificationType`)
- 알림 메시지 DTO 정의 (`NotificationMessage`)

### Redis Pub/Sub
- `NotificationMessagePublisher` 구현 — `auction:notification` 채널로 메시지 발행

### 알림 발행 시점
- 새 입찰 발생 시 구매자에게 `NEW_BID` 발행
- 새로운 최저가 입찰 갱신 시 기존 최저가 입찰자에게 `LOWEST_BID_UPDATED` 발행

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로운 알림 서비스 추가 (포트 8081)
  * 향상된 인증 설정 (Google, Kakao, Naver)
  * 새로운 입찰 알림 및 최저가 업데이트 알림

* **개선 사항**
  * Java 21로 업그레이드하여 성능 및 안정성 향상
  * 알림 처리 방식 최적화

* **변경 사항**
  * Kafka 메시지 브로커에서 Redis 기반 알림 시스템으로 마이그레이션

<!-- end of auto-generated comment: release notes by coderabbit.ai -->