### PR TITLE
[FEAT] CI/CD를 새 환경에 맞게 변경, 그리고 수동 배포로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,10 +1,17 @@
 name: CD Pipeline
 
+# 수동으로 실행하는 배포 파이프라인입니다.
+# 배포할 커밋 해시를 입력하면 해당 커밋 기준으로 빌드 및 배포가 진행됩니다.
+# 입력값을 비워두면 이 워크플로우를 트리거한 커밋이 배포됩니다
+
 on:
-  workflow_run:
-    workflows: [ "CI-BASIC" ]
-    types: [ completed ] # CI가 통과된 이후에 실행됩니다
-    branches: [ main, dev ]
+  workflow_dispatch:
+    inputs:
+      sha_to_deploy:
+        description: '실제 배포할 commit hash를 입력해주세요'
+        type: string
+        default: ''
+
 
 # OIDC 토큰 요청 권한
 permissions:
@@ -14,21 +21,53 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
     outputs:
-      image_tag: ${{ steps.vars.outputs.short_sha }}
+      short_sha: ${{ steps.vars.outputs.short_sha }}
+      full_sha: ${{ steps.vars.outputs.full_sha }}
 
     steps:
       # 코드 가져오기
+      # 모든 브랜치를 가져옵니다
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
 
-      # 커밋 해시 추출
-      - name: Set short SHA
+      # 커밋 해시 있는지 확인후 추출
+      - name: Check SHA exists and checkout
         id: vars
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        env: 
+          SHA_TO_DEPLOY: ${{ inputs.sha_to_deploy }}
+        run: |
+          set -euo pipefail
+
+          if [ "$SHA_TO_DEPLOY" != "" ]; then
+              # extract sha if it even exists
+
+              set +e
+              FULL_SHA=$( git rev-parse -q --verify "$SHA_TO_DEPLOY^{commit}" )
+              GIT_COMMIT_CHECK_RESULT=$?
+              set -e
+
+              if [ $GIT_COMMIT_CHECK_RESULT == 0 ]; then
+                  echo "git commit is ${FULL_SHA}"
+              else
+                  echo "git commit \"${SHA_TO_DEPLOY}\" does not exist!"
+                  exit 1
+              fi
+          else
+              FULL_SHA=$GITHUB_SHA
+          fi
+
+          # extract short sha
+          SHORT_SHA=$(git rev-parse --short "$FULL_SHA")
+
+          # save it to github environment
+          echo "full_sha=${FULL_SHA}" >> $GITHUB_OUTPUT
+
+          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+
+          git checkout $FULL_SHA
 
       # Java 21 설치
       - name: Setup Java 21
@@ -77,9 +116,16 @@ jobs:
 
       # Docker 빌드 및 push
       - name: Build and push Docker image
+        env:
+          SHORT_SHA: ${{ steps.vars.outputs.short_sha }}
+
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |
-          SHORT_SHA=${{ steps.vars.outputs.short_sha }}
-          IMAGE_URI=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY }}
+          set -euo pipefail
+
+          IMAGE_URI="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}"
 
           # Docker 빌드 및 push
           docker buildx build --platform linux/arm64 -t $IMAGE_URI:$SHORT_SHA --push .
@@ -88,9 +134,6 @@ jobs:
 
   deploy:
     needs: build
-    if: github.event.workflow_run.event == 'push'
-    # 일단은 dev에서도 해보죠!
-    # if: github.ref == 'refs/heads/main'   # main push에서만 배포 (PR에서는 CI만 실행)
     runs-on: ubuntu-latest
 
     steps:
@@ -105,72 +148,61 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ needs.build.outputs.full_sha }}
 
-      # EC2 한테 docker pull 받아오라고 하기
-      - name: Tell EC2 to pull from docker and run it
+      # ECS 태스크및 서비스 업데이트
+      - name: Ecs, update Task Definition and Update Service
         env:
-          IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+          IMAGE_TAG: ${{ needs.build.outputs.short_sha }}
+
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           AWS_INSTANCE_ID: ${{ secrets.AWS_INSTANCE_ID }}
+
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+
+          TASK_FAMILY: ${{ secrets.TASK_FAMILY }}
+
+          AWS_TASK_ROLE_ARN: ${{ secrets.AWS_TASK_ROLE_ARN }}
+          AWS_EXECUTION_ROLE_ARN: ${{ secrets.AWS_EXECUTION_ROLE_ARN }}
+
+          AWS_ECS_SERVICE_ARN: ${{ secrets.AWS_ECS_SERVICE_ARN }}
+          AWS_ECS_CLUSTER_ARN: ${{ secrets.AWS_ECS_CLUSTER_ARN }}
 
         run: |
           set -euo pipefail
 
           ECR_URI="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG}"
 
-          IMAGES_TO_DELETE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}*"
+          # task_definition.json에 적혀 있는 secret들을
+          # 실제 값으로 치환
 
-          COMPOSE_B64=$(base64 -w0 docker-compose-prod.yml)
+          TASK_DEF=$(cat task_definition.json \
+            | sed -e "s|__TASK_FAMILY__|${TASK_FAMILY}|g" \
+            | sed -e "s|__AWS_TASK_ROLE_ARN__|${AWS_TASK_ROLE_ARN}|g" \
+            | sed -e "s|__AWS_EXECUTION_ROLE_ARN__|${AWS_EXECUTION_ROLE_ARN}|g" \
+            | sed -e "s|__ECR_URI__|${ECR_URI}|g" \
+            | sed -e "s|__AWS_REGION__|${AWS_REGION}|g" \
+          )
 
-          cat > ssm-params.json <<JSON
-          {
-              "commands": [
-                  "set -euo pipefail",
-                  "docker version",
-                  "cd /home/ec2-user/app",
-                  "set +e",
-                  "docker rm -v -f \$(docker ps -qa)",
-                  "docker rmi \$(docker images \"$IMAGES_TO_DELETE\" -q)",
-                  "set -e",
-                  "echo $COMPOSE_B64 | base64 -d - > docker-compose.yml",
-                  "docker pull \"$ECR_URI\"",
-                  "ECR_URI=\"$ECR_URI\" docker compose up -d"
-              ]
-          }
-          JSON
+          echo "$TASK_DEF" > task-definition-out.json
 
-          COMMAND_ID=$(
-              aws ssm send-command \
-                  --region "$AWS_REGION" \
-                  --instance-ids "$AWS_INSTANCE_ID" \
-                  --document-name "AWS-RunShellScript" \
-                  --comment "deploy auction spring server" \
-                  --parameters file://ssm-params.json \
-                  --query "Command.CommandId" \
-                  --output text
-              )
+          # task 업데이트
 
-          echo "SSM CommandId: $COMMAND_ID"
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+              --cli-input-json file://./task-definition-out.json \
+              --output json \
+              --query "taskDefinition.taskDefinitionArn" \
+          )
 
-          set +e
-          aws ssm wait command-executed \
-              --region "$AWS_REGION" \
-              --command-id "$COMMAND_ID" \
-              --instance-id "$AWS_INSTANCE_ID" \
-              --cli-connect-timeout 180 \
-              --cli-read-timeout 180
-          COMMAND_RESULT=$?
-          set -e
+          # 서비스 업데이트
 
-          aws ssm get-command-invocation \
-              --region "$AWS_REGION" \
-              --command-id "$COMMAND_ID" \
-              --instance-id "$AWS_INSTANCE_ID" \
-              --query "{Status:Status,ResponseCode:ResponseCode,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
-              --output json
+          # remove double quotes
+          TASK_DEF_ARN=${TASK_DEF_ARN//\"/}
 
-          exit $COMMAND_RESULT
+          aws ecs update-service \
+              --cluster "${AWS_ECS_CLUSTER_ARN}" \
+              --service "${AWS_ECS_SERVICE_ARN}" \
+              --task-definition "${TASK_DEF_ARN}" \
+              --force-new-deployment
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,6 +66,17 @@ jobs:
           # extract short sha
           SHORT_SHA=$(git rev-parse --short "$FULL_SHA")
 
+          # reject deploy it is't not part of dev/main
+          git fetch origin \
+              '+refs/heads/main:refs/remotes/origin/main' \
+              '+refs/heads/dev:refs/remotes/origin/dev'
+
+          if ! git merge-base --is-ancestor "$FULL_SHA" origin/dev \
+              && ! git merge-base --is-ancestor "$FULL_SHA" origin/main; then
+              echo "commit ${FULL_SHA} is not reachable from dev/main"
+              exit 1
+          fi
+
           # save it to github environment
           echo "full_sha=${FULL_SHA}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -172,7 +172,6 @@ jobs:
 
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_INSTANCE_ID: ${{ secrets.AWS_INSTANCE_ID }}
 
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,10 @@ permissions:
   id-token: write   # OIDC 토큰 요청용
   contents: read    # 코드 체크아웃용
 
+concurrency:
+  group: cd-production
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "corretto"
           java-version: "21"

--- a/task_definition.json
+++ b/task_definition.json
@@ -1,0 +1,70 @@
+{
+    "family": "__TASK_FAMILY__",
+    "taskRoleArn": "__AWS_TASK_ROLE_ARN__",
+    "executionRoleArn": "__AWS_EXECUTION_ROLE_ARN__",
+    "networkMode": "awsvpc",
+    "containerDefinitions": [
+        {
+            "name": "auction-spring",
+            "image": "__ECR_URI__",
+            "portMappings": [
+                {
+                    "containerPort": 8080,
+                    "hostPort": 8080,
+                    "protocol": "tcp",
+                    "appProtocol": "http"
+                }
+            ],
+            "essential": true,
+            "environment": [
+                {
+                    "name": "SPRING_DATA_REDIS_SSL_ENABLED",
+                    "value": "true"
+                },
+                {
+                    "name": "SPRING_DATA_REDIS_PROTOCOL",
+                    "value": "valkeys"
+                },
+                {
+                    "name": "SPRING_PROFILES_ACTIVE",
+                    "value": "prod"
+                }
+            ],
+            "startTimeout": 300,
+            "stopTimeout": 120,
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "fargate-spring",
+                    "awslogs-create-group": "true",
+                    "awslogs-region": "__AWS_REGION__",
+                    "awslogs-stream-prefix": "spring"
+                }
+            },
+            "healthCheck": {
+                "command": [
+                    "CMD-SHELL",
+                    "curl --fail --silent localhost:8080/actuator/health | grep UP || exit 1"
+                ],
+                "interval": 10,
+                "timeout": 5,
+                "retries": 5,
+                "startPeriod": 300
+            },
+            "systemControls": []
+        }
+    ],
+    "requiresCompatibilities": [ "FARGATE" ],
+    "cpu": "512",
+    "memory": "1024",
+    "runtimePlatform": {
+        "cpuArchitecture": "ARM64",
+        "operatingSystemFamily": "LINUX"
+    },
+    "tags": [
+        {
+            "key": "reverse-auction",
+            "value": ""
+        }
+    ]
+}

--- a/task_definition.json
+++ b/task_definition.json
@@ -30,7 +30,7 @@
                     "value": "prod"
                 }
             ],
-            "startTimeout": 300,
+            "startTimeout": 120,
             "stopTimeout": 120,
             "logConfiguration": {
                 "logDriver": "awslogs",


### PR DESCRIPTION
## 📝 작업 내용

- CI에 있던 action 버전들을 업데이트 함
- CD를 새로 구축한 환경에 맞게 수정
- CD를 수동 배포로 변경 (반 CD :^) )

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항

예전에는 ECS한테 올린 다음에 그 image를 EC2한테 pull 받으라고 명령했습니다.
    
이제는 그일의 대부분을 ECS가 합니다.
    
저희는 ECS한테 task definition을 새로 전달한후 이 service 한테 새로 만든 task로 돌리라고만 하면 됩니다.
    
cd.yml이 더 길어진 이유는 자동배포에서 수동 배포로 옮겼기 때문입니다.
    
전에는 dev나 main에 merge가 될 때 마다 서버를 업데이트 했다면 이 PR 이후로는 github한테 어떤 commit을 올리고 싶다고 얘기한뒤 올리게 됩니다.
    
저희가 일단 실 client가 없고 기술 stack 이 자주 바뀌기 때문에 이 방향이 맞는 듣 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 배포가 수동 트리거로 전환되어 배포 커밋을 직접 지정할 수 있습니다.
  * 배포 동시성 제어가 추가되었습니다.
  * AWS ECS Fargate 기반 배포 지원이 추가되어 서비스가 새로운 태스크 정의로 교체되어 배포됩니다.
  * 배포 시 커밋 식별자(short/full SHA)를 사용한 이미지 태깅 및 추적이 개선되었습니다.

* **Chores**
  * CI 액션 버전이 업데이트되었습니다 (체크아웃, Java 설정).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->