### PR TITLE
[FIX]: 경매 서비스에서 삭제된 유저는 조회하지 말기

### DIFF
--- a/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
@@ -121,7 +121,7 @@ public class AuctionService {
             CreateAuctionRequest req
     ) {
         // 경매 생성은 중요한 작업이기 때문에 JWT만을 믿지 않고 DB에 유저가 있는지 확인
-        userRepository.findById(userDetails.getUserId()).orElseThrow(()->
+        userRepository.findByIdAndDeletedFalse(userDetails.getUserId()).orElseThrow(()->
             new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND)
         );
 
@@ -180,7 +180,7 @@ public class AuctionService {
         LocalDateTime now = LocalDateTime.now();
 
         // 경매 취소는 중요한 작업이기 때문에 JWT만을 믿지 않고 DB에 유저가 있는지 확인
-        userRepository.findById(details.getUserId()).orElseThrow(()->
+        userRepository.findByIdAndDeletedFalse(details.getUserId()).orElseThrow(()->
             new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND)
         );
 

--- a/src/test/java/com/example/auction/domain/auction/service/AuctionServiceCancelTest.java
+++ b/src/test/java/com/example/auction/domain/auction/service/AuctionServiceCancelTest.java
@@ -108,7 +108,7 @@ class AuctionServiceCancelTest {
         );
         ReflectionTestUtils.setField(auction, "id", 1L);
 
-        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(userRepository.findByIdAndDeletedFalse(user.getId())).willReturn(Optional.of(user));
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
 
         // WHEN & THEN 
@@ -195,7 +195,7 @@ class AuctionServiceCancelTest {
     private User createMockUser() {
         User user = User.of("test@test.com", "encodedPassword", UserRole.USER);
         ReflectionTestUtils.setField(user, "id", 1L);
-        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(userRepository.findByIdAndDeletedFalse(user.getId())).willReturn(Optional.of(user));
 
         return user;
     }


### PR DESCRIPTION
## 📝 작업 내용

경매 서비스에서 유저 조회시 삭제된 유저는 조회하지 않도록 수정했습니다.

## 🔗 관련 이슈 (Related Issues)
#34 의 일부를 개선합니다. (hhjo96님도 고칠게 있다고 하셔서 close를 하지는 않겠습니다.)

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 논리적으로 삭제된 사용자가 경매 생성 및 취소 작업을 수행하는 것을 방지하도록 강화했습니다. 삭제된 사용자 계정은 이제 유효하지 않은 것으로 올바르게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->