### PR TITLE
[FEAT] 입찰에서 삭제된 유저 제외

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,29 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+  influxdb:
+    image: influxdb:1.8
+    container_name: auction-influxdb
+    ports:
+      - "8086:8086"
+    environment:
+      INFLUXDB_DB: k6
+    volumes:
+      - influxdb-data:/var/lib/influxdb
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: auction-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - influxdb
 
 volumes:
   postgres-data:
+  influxdb-data:
+  grafana-data:

--- a/src/main/java/com/example/auction/common/config/RedissonConfig.java
+++ b/src/main/java/com/example/auction/common/config/RedissonConfig.java
@@ -1,0 +1,28 @@
+package com.example.auction.common.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.protocol:redis}")
+    private String redisProtocol;
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(redisProtocol + "://" + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/example/auction/domain/bid/repository/BidCustomRepository.java
+++ b/src/main/java/com/example/auction/domain/bid/repository/BidCustomRepository.java
@@ -1,4 +1,11 @@
 package com.example.auction.domain.bid.repository;
 
+import com.example.auction.domain.bid.entity.Bid;
+import java.util.Optional;
+
 public interface BidCustomRepository {
+
+    // 현재 최저가입찰 전체 조회(삭제된유저 제외)
+    Optional<Bid> findFirstByAuctionIdOrderByPriceAsc(Long auctionId);
+
 }

--- a/src/main/java/com/example/auction/domain/bid/repository/BidCustomRepositoryImpl.java
+++ b/src/main/java/com/example/auction/domain/bid/repository/BidCustomRepositoryImpl.java
@@ -22,7 +22,7 @@ public class BidCustomRepositoryImpl implements BidCustomRepository {
                         bid.auctionId.eq(auctionId),
                         user.deleted.isFalse()
                 )
-                .orderBy(bid.price.asc())
+                .orderBy(bid.price.asc(), bid.createdAt.asc())
                 .limit(1)
                 .fetchOne();
 

--- a/src/main/java/com/example/auction/domain/bid/repository/BidCustomRepositoryImpl.java
+++ b/src/main/java/com/example/auction/domain/bid/repository/BidCustomRepositoryImpl.java
@@ -1,10 +1,31 @@
 package com.example.auction.domain.bid.repository;
 
+import com.example.auction.domain.bid.entity.Bid;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+
+import static com.example.auction.domain.bid.entity.QBid.bid;
+import static com.example.auction.domain.user.entity.QUser.user;
 
 @RequiredArgsConstructor
 public class BidCustomRepositoryImpl implements BidCustomRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Bid> findFirstByAuctionIdOrderByPriceAsc(Long auctionId) {
+        Bid result = queryFactory
+                .selectFrom(bid)
+                .join(user).on(bid.userId.eq(user.id))
+                .where(
+                        bid.auctionId.eq(auctionId),
+                        user.deleted.isFalse()
+                )
+                .orderBy(bid.price.asc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
 }

--- a/src/main/java/com/example/auction/domain/bid/repository/BidRepository.java
+++ b/src/main/java/com/example/auction/domain/bid/repository/BidRepository.java
@@ -13,14 +13,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BidRepository extends JpaRepository<Bid, Long>, BidCustomRepository {
-    Optional<Bid> findFirstByAuctionIdOrderByPriceAsc(Long auctionId);
 
     Page<Bid> findAllByUserId(Long userId, Pageable pageable);
 
     Page<Bid> findAllByAuctionId(Long auctionId, Pageable pageable);
-
-    @Query("SELECT MIN(b.price) FROM Bid b WHERE b.auctionId = :auctionId")
-    Optional<BigDecimal> findMinPriceByAuctionId(@Param("auctionId") Long auctionId);
 
     boolean existsByUserIdAndStatus(Long userId, BidAuctionStatus bidAuctionStatus);
 }

--- a/src/main/java/com/example/auction/domain/bid/repository/BidRepository.java
+++ b/src/main/java/com/example/auction/domain/bid/repository/BidRepository.java
@@ -5,12 +5,6 @@ import com.example.auction.domain.bid.enums.BidAuctionStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Optional;
 
 public interface BidRepository extends JpaRepository<Bid, Long>, BidCustomRepository {
 

--- a/src/main/java/com/example/auction/domain/bid/service/BidCommandProcessor.java
+++ b/src/main/java/com/example/auction/domain/bid/service/BidCommandProcessor.java
@@ -72,16 +72,15 @@ public class BidCommandProcessor {
         }
 
         // 현재 최저가보다 낮아야 함
-        BigDecimal currentMinPrice = bidRepository.findMinPriceByAuctionId(auctionId).orElse(null);
+        Bid currentMin = bidRepository.findFirstByAuctionIdOrderByPriceAsc(auctionId).orElse(null);
+        BigDecimal currentMinPrice = currentMin != null ? currentMin.getPrice() : null;
 
+        // currentMinPrice 가 null일경우 bidPrice 가격검증 스킵됨
         if (currentMinPrice != null && bidPrice.compareTo(currentMinPrice) >= 0) {
             log.warn("[입찰 실패] auctionId={}, userId={}, bidPrice={}, currentMinPrice={}",
                     auctionId, userId, bidPrice, currentMinPrice);
             throw new ServiceErrorException(BidErrorEnum.BID_PRICE_NOT_LOWER);
         }
-
-        // 기존 최저가 입찰 조회
-        Bid currentMin = bidRepository.findFirstByAuctionIdOrderByPriceAsc(auctionId).orElse(null);
 
         // 입찰 생성 및 저장
         Bid bid = Bid.of(
@@ -103,7 +102,7 @@ public class BidCommandProcessor {
                 ));
 
                 // 최저가 갱신 알림
-                if (currentMinPrice != null && currentMin != null) {
+                if (currentMinPrice != null) {
                     notificationMessagePublisher.publish(new NotificationMessage(
                             NotificationType.LOWEST_BID_UPDATED, currentMin.getUserId(), auctionId, auction.getItemName()
                     ));

--- a/src/main/java/com/example/auction/domain/bid/service/BidQueryService.java
+++ b/src/main/java/com/example/auction/domain/bid/service/BidQueryService.java
@@ -33,7 +33,7 @@ public class BidQueryService {
     private final AuctionResultRepository resultRepository;
 
 
-    // 내 입찰 조회
+    // 내 입찰 조회(로그인한 본인만 가능하므로 삭제된 유저 처리 X)
     public PageResponse<BidListResponse> getMyBids(CustomUserDetails userDetails, Pageable pageable) {
 
         Long userId = userDetails.getUserId();
@@ -48,7 +48,7 @@ public class BidQueryService {
         return PageResponse.create(myBidPage);
     }
 
-    // 특정 경매의 입찰조회
+    // 특정 경매의 입찰조회(삭제된 유저의 입찰 조회 가능)
     public PageResponse<BidListResponse> getBids(CustomUserDetails userDetails, Long auctionId, Pageable pageable) {
         // 경매 존재 여부 및 상태 확인
         Auction auction = auctionRepository.findById(auctionId)
@@ -65,7 +65,7 @@ public class BidQueryService {
         return PageResponse.create(bidPage);
     }
 
-    // 입찰 결과 조회(1건)
+    // 입찰 결과 조회(1건, 삭제된 유저의 입찰 조회 가능)
     public BidResponse getWinnerBid(CustomUserDetails userDetails, Long auctionId) {
 
         // 경매 존재 여부 및 상태 확인
@@ -88,6 +88,7 @@ public class BidQueryService {
 
     }
 
+    // 현재 최저가 입찰 조회(삭제된 유저의 입찰 제외)
     public BidResponse getCurrentMinBid(CustomUserDetails userDetails, Long auctionId) {
         // 경매 존재 여부 및 상태 확인
         Auction auction = auctionRepository.findById(auctionId)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,6 +31,9 @@ spring:
 
   data:
     redis:
+      ssl:
+        enabled: ${SPRING_DATA_REDIS_SSL_ENABLED:false}
+      protocol: ${REDIS_PROTOCOL:redis}
       host: ${REDIS_HOST:localhost}
       port: 6379
 aws:

--- a/src/test/java/com/example/auction/domain/bid/service/BidCommandProcessorTest.java
+++ b/src/test/java/com/example/auction/domain/bid/service/BidCommandProcessorTest.java
@@ -11,8 +11,10 @@ import com.example.auction.domain.bid.entity.Bid;
 import com.example.auction.domain.bid.enums.BidAuctionStatus;
 import com.example.auction.domain.bid.exceptions.BidErrorEnum;
 import com.example.auction.domain.bid.repository.BidRepository;
+import com.example.auction.domain.notification.publisher.NotificationMessagePublisher;
 import com.example.auction.domain.user.entity.User;
 import com.example.auction.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -47,12 +50,20 @@ class BidCommandProcessorTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private NotificationMessagePublisher publisher;
+
     private CustomUserDetails userDetails;
     private Long auctionId;
     private Auction activeAuction;
 
     @BeforeEach
     void setUp() {
+
+        // TransactionSynchronizationManager 는 트랜잭션 동기화가 활성화되어야 호출 가능한데 단위테스트라서 트랜잭션이 없음
+        // 그래서 수동으로 트랜잭션 동기화 실행, 각 테스트 종료 후 해제
+        TransactionSynchronizationManager.initSynchronization();
+
         userDetails = new CustomUserDetails(1L, "USER");  // 입찰자(판매자) userId = 1
         auctionId = 10L;
 
@@ -71,6 +82,11 @@ class BidCommandProcessorTest {
         activeAuction.activate();
     }
 
+    @AfterEach
+    void tearDown() {
+        TransactionSynchronizationManager.clearSynchronization();
+    }
+
     // ========================
     // 입찰 생성 성공 케이스
     // ========================
@@ -82,7 +98,7 @@ class BidCommandProcessorTest {
         Bid savedBid = Bid.of(null, BigDecimal.valueOf(150_000), auctionId, userDetails.getUserId(), BidAuctionStatus.ACTIVE);
 
         given(auctionRepository.findById(auctionId)).willReturn(Optional.of(activeAuction));
-        given(bidRepository.findMinPriceByAuctionId(auctionId)).willReturn(Optional.empty());
+        given(bidRepository.findFirstByAuctionIdOrderByPriceAsc(auctionId)).willReturn(Optional.empty());
         given(bidRepository.save(any(Bid.class))).willReturn(savedBid);
 
         // when
@@ -103,7 +119,7 @@ class BidCommandProcessorTest {
         Bid savedBid = Bid.of(null, BigDecimal.valueOf(200_000), auctionId, userDetails.getUserId(), BidAuctionStatus.ACTIVE);
 
         given(auctionRepository.findById(auctionId)).willReturn(Optional.of(activeAuction));
-        given(bidRepository.findMinPriceByAuctionId(auctionId)).willReturn(Optional.empty());
+        given(bidRepository.findFirstByAuctionIdOrderByPriceAsc(auctionId)).willReturn(Optional.empty());
         given(bidRepository.save(any(Bid.class))).willReturn(savedBid);
 
         // when
@@ -125,9 +141,11 @@ class BidCommandProcessorTest {
         BigDecimal newBidPrice = BigDecimal.valueOf(100000);  // 현재 최저가보다 낮음
         BidRequest request = new BidRequest(newBidPrice, null);
         Bid savedBid = Bid.of(null, newBidPrice, auctionId, userDetails.getUserId(), BidAuctionStatus.ACTIVE);
+        Bid mockCurrentMin = mock(Bid.class);
 
         given(auctionRepository.findById(auctionId)).willReturn(Optional.of(activeAuction));
-        given(bidRepository.findMinPriceByAuctionId(auctionId)).willReturn(Optional.of(currentMinPrice));
+        given(mockCurrentMin.getPrice()).willReturn(currentMinPrice);
+        given(bidRepository.findFirstByAuctionIdOrderByPriceAsc(auctionId)).willReturn(Optional.of(mockCurrentMin));
         given(bidRepository.save(any(Bid.class))).willReturn(savedBid);
 
         // when
@@ -148,8 +166,10 @@ class BidCommandProcessorTest {
         // given
         BigDecimal currentMinPrice = BigDecimal.valueOf(150_000);
         BidRequest request = new BidRequest(currentMinPrice, null);
+        Bid mockCurrentMin = mock(Bid.class);
 
-        given(bidRepository.findMinPriceByAuctionId(auctionId)).willReturn(Optional.of(currentMinPrice));
+        given(mockCurrentMin.getPrice()).willReturn(currentMinPrice);
+        given(bidRepository.findFirstByAuctionIdOrderByPriceAsc(auctionId)).willReturn(Optional.of(mockCurrentMin));
         given(auctionRepository.findById(auctionId)).willReturn(Optional.of(activeAuction));
 
         // when & then
@@ -164,8 +184,11 @@ class BidCommandProcessorTest {
         // given
         BigDecimal currentMinPrice = BigDecimal.valueOf(150000);
         BidRequest request = new BidRequest(BigDecimal.valueOf(200_000), null);  // 최저가보다 높음
+        Bid mockCurrentMin = mock(Bid.class);
 
-        given(bidRepository.findMinPriceByAuctionId(auctionId)).willReturn(Optional.of(currentMinPrice));
+
+        given(mockCurrentMin.getPrice()).willReturn(currentMinPrice);
+        given(bidRepository.findFirstByAuctionIdOrderByPriceAsc(auctionId)).willReturn(Optional.of(mockCurrentMin));
         given(auctionRepository.findById(auctionId)).willReturn(Optional.of(activeAuction));
 
         // when & then


### PR DESCRIPTION
## 📝 작업 내용
- 현재 최저가 입찰에서 삭제된 유저의 입찰이 포함되지 않도록 수정(다른 코드는 수정사항 없음)
- redisson config 추가

### 입찰 삭제 관련 규칙
- 입찰 생성-> 삭제된 유저 불가능(이미 그렇게 되어 있음)
- 특정경매의 입찰조회 -> 삭제된유저의 입찰 조회 가능
- 입찰결과 조회-> 삭제된 유저의 입찰 조회 가능
- 현재 최저가입찰 조회 -> 삭제된 유저의 입찰 제외
- 내입찰조회 -> 삭제된 유저라면 로그인이 불가능하므로 별도 처리 X


## 🔗 관련 이슈 (Related Issues)
Closes #34 

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항
- TransactionSynchronizationManager 추가 후 테스트 코드가 작동하지 않아서, 테스트 코드도 같이 수정했습니다.
- 부하테스트를 위해 k6과 그라파나를 도커컴포즈에 추가해두었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * InfluxDB 및 Grafana 기반 모니터링 스택 추가(지속 볼륨 및 포트 노출).
  * Redis 연결에 대한 TLS 활성화 및 프로토콜 설정 옵션 추가.

* **리팩터링**
  * 입찰 최저가 조회 로직 단순화 및 성능 개선.

* **테스트**
  * 입찰 관련 테스트의 동기화 및 목(Mock) 설정 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->