### PR TITLE
[FEAT] 가상 스레드 전환

### DIFF
--- a/src/main/java/com/example/auction/domain/ai/listener/AuctionEmbedListener.java
+++ b/src/main/java/com/example/auction/domain/ai/listener/AuctionEmbedListener.java
@@ -13,11 +13,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 @Slf4j
 @Component
@@ -29,13 +25,8 @@ public class AuctionEmbedListener implements MessageListener {
     // 처리 중 중복 요청 차단용 — 10분 TTL로 크래시 시 자동 해제
     private static final String EMBED_LOCK_KEY_PREFIX = "embed:lock:auction:";
 
-    // JPA + OpenAI 블로킹 호출 전용 풀 — 유한 큐(100) + 포화 시 호출자 스레드 실행
-    private final ExecutorService embedExecutor = new ThreadPoolExecutor(
-            2, 4,
-            60L, TimeUnit.SECONDS,
-            new ArrayBlockingQueue<>(100),
-            new ThreadPoolExecutor.CallerRunsPolicy()
-    );
+    // JPA + OpenAI 블로킹 호출 전용 가상 스레드 Executor - Tomcat 요청 스레드와 격리
+    private final ExecutorService embedExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
     private final AuctionRepository auctionRepository;
     private final AuctionEmbeddingService auctionEmbeddingService;

--- a/src/main/java/com/example/auction/domain/ai/service/ReviewEmbeddingService.java
+++ b/src/main/java/com/example/auction/domain/ai/service/ReviewEmbeddingService.java
@@ -29,8 +29,8 @@ public class ReviewEmbeddingService {
     private static final int HYDE_TIMEOUT_SECONDS = 5;
     private static final int HYDE_CACHE_MAX_SIZE = 50;
 
-    // ForkJoinPool.commonPool() 대신 전용 executor — blocking HTTP 호출로 commonPool 고갈 방지
-    private static final ExecutorService hydeExecutor = Executors.newFixedThreadPool(4);
+    // blocking HTTP 호출 전용 가상 스레드 Executor — Tomcat 요청 스레드와 격리
+    private static final ExecutorService hydeExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
     private final VectorStore vectorStore;
     private final ChatModel chatModel;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   application:
     name: auction
+
   autoconfigure:
     exclude:
       - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechAutoConfiguration
@@ -48,6 +49,11 @@ spring:
       # 기본적으로 parameterstore는 비활성화
       parameterstore:
         enabled: false
+
+  # 가상 스레드 관련
+  threads:
+    virtual:
+      enabled: true
 
 # actuator 관련
 # 일단은 ALB나 ASG 를 위해서 health end point를 열어둡니다.


### PR DESCRIPTION
## 📝 작업 내용
- `spring.threads.virtual.enabled=true` 설정으로 Tomcat 요청 스레드 및 `@Async` 기본 Executor 가상 스레드 전환
- `AuctionEmbedListener.embedExecutor` — `ThreadPoolExecutor(2, 4)` → `newVirtualThreadPerTaskExecutor()`                                                                                              
- `ReviewEmbeddingService.hydeExecutor` — `newFixedThreadPool(4)` → `newVirtualThreadPerTaskExecutor()`

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항
자세한 내용은 5분 기록 보드에 작성해놨습니다!