### PR TITLE
[FEAT] 시작시간, 종료시간 기반으로 변경

### DIFF
--- a/src/main/java/com/example/auction/domain/bid/service/BidCommandProcessor.java
+++ b/src/main/java/com/example/auction/domain/bid/service/BidCommandProcessor.java
@@ -56,8 +56,14 @@ public class BidCommandProcessor {
         Auction auction = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new ServiceErrorException(AuctionErrorEnum.AUCTION_NOT_FOUND));
 
-        // 경매 상태 검증 (ACTIVE만 입찰 가능)
-        if (auction.getStatus() != AuctionStatus.ACTIVE) {
+        // 취소된 경매 입찰 불가
+        if (auction.getStatus() == AuctionStatus.CANCELLED) {
+            throw new ServiceErrorException(AuctionErrorEnum.AUCTION_INVALID_STATUS);
+        }
+
+        // 경매 시간 검증(경매 시작 시간 <= 입찰 발생 시간 <= 경매 종료 시간)
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(auction.getStartedAt()) || now.isAfter(auction.getEndedAt())) {
             throw new ServiceErrorException(AuctionErrorEnum.AUCTION_INVALID_STATUS);
         }
 

--- a/src/test/java/com/example/auction/domain/bid/service/BidCommandProcessorTest.java
+++ b/src/test/java/com/example/auction/domain/bid/service/BidCommandProcessorTest.java
@@ -79,7 +79,6 @@ class BidCommandProcessorTest {
         );
         given(userRepository.findByIdAndDeletedFalse(anyLong()))
                 .willReturn(Optional.of(mock(User.class)));
-        activeAuction.activate();
     }
 
     @AfterEach
@@ -198,8 +197,28 @@ class BidCommandProcessorTest {
     }
 
     @Test
-    @DisplayName("READY 상태 경매에 입찰 시 실패")
-    void auction_ready_bid_fail() {
+    @DisplayName("취소된 경매에 입찰 시 실패")
+    void auction_cancelled_bid_fail() {
+        // given
+        BidRequest request = new BidRequest(BigDecimal.valueOf(150_000), null);
+        Auction cancelledAuction = Auction.of(
+                99L, "테스트", BigDecimal.valueOf(200_000), "상품",
+                LocalDateTime.now().minusHours(1),
+                LocalDateTime.now().plusHours(1),
+                1L
+        );
+        cancelledAuction.cancel();  // READY -> CANCELLED
+        given(auctionRepository.findById(auctionId)).willReturn(Optional.of(cancelledAuction));
+
+        // when & then
+        assertThatThrownBy(() -> processor.placeBid(userDetails, auctionId, request))
+                .isInstanceOf(ServiceErrorException.class)
+                .hasMessage(AuctionErrorEnum.AUCTION_INVALID_STATUS.getMessage());
+    }
+
+    @Test
+    @DisplayName("경매 시작 전에 입찰 시 실패")
+    void not_started_auction_bid_fail() {
         // given
         BidRequest request = new BidRequest(BigDecimal.valueOf(150_000), null);
         Auction readyAuction = Auction.of(
@@ -217,8 +236,8 @@ class BidCommandProcessorTest {
     }
 
     @Test
-    @DisplayName("DONE 상태 경매에 입찰 시 실패")
-    void auction_done_bid_fail() {
+    @DisplayName("경매 종료 후에 입찰 시 실패")
+    void ended_auction_bid_fail() {
         // given
         BidRequest request = new BidRequest(BigDecimal.valueOf(150_000), null);
         Auction doneAuction = Auction.of(


### PR DESCRIPTION
## 📝 작업 내용
- 경매 상태 기반 입찰 -> 경매시간 기반 입찰 변경

## 🔗 관련 이슈 (Related Issues)
Closes #

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 경매 입찰 검증을 강화했습니다. 취소된 경매에 대한 입찰을 차단하고, 경매의 시작 시간과 종료 시간 범위 내에서만 입찰이 가능하도록 변경했습니다.

* **테스트**
  * 경매 상태 검증에 대한 테스트 커버리지를 확대했습니다. 취소된 경매, 아직 시작되지 않은 경매, 종료된 경매 사례에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->