### PR TITLE
[FIX] Auth, User, Category, Review 튜터님 피드백 반영

### DIFF
--- a/src/main/java/com/example/auction/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/auction/common/config/security/SecurityConfig.java
@@ -42,6 +42,8 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/refresh").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/reviews/written").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/reviews/received").authenticated()
                         .requestMatchers(HttpMethod.GET,"/api/reviews/{reviewId}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/example/auction/domain/auth/dto/AuthSignupRequest.java
+++ b/src/main/java/com/example/auction/domain/auth/dto/AuthSignupRequest.java
@@ -1,9 +1,7 @@
 package com.example.auction.domain.auth.dto;
 
-import com.example.auction.domain.user.enums.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record AuthSignupRequest(
@@ -13,8 +11,5 @@ public record AuthSignupRequest(
 
         @NotBlank(message = "비밀번호를 입력해주세요")
         @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다")
-        String password,
-
-        @NotNull(message = "역할을 선택해주세요")
-        UserRole role
+        String password
 ) {}

--- a/src/main/java/com/example/auction/domain/auth/exception/AuthErrorEnum.java
+++ b/src/main/java/com/example/auction/domain/auth/exception/AuthErrorEnum.java
@@ -13,7 +13,8 @@ public enum AuthErrorEnum implements ErrorEnumInterface {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
     SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다"),
     SOCIAL_LOGIN_EMAIL_CONFLICT(HttpStatus.CONFLICT, "이미 일반 회원가입으로 가입된 이메일입니다"),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다");
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다"),
+    LOGIN_LOCKED(HttpStatus.TOO_MANY_REQUESTS, "로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/auction/domain/auth/exception/AuthErrorEnum.java
+++ b/src/main/java/com/example/auction/domain/auth/exception/AuthErrorEnum.java
@@ -12,7 +12,8 @@ public enum AuthErrorEnum implements ErrorEnumInterface {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
     SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다"),
-    SOCIAL_LOGIN_EMAIL_CONFLICT(HttpStatus.CONFLICT, "이미 일반 회원가입으로 가입된 이메일입니다");
+    SOCIAL_LOGIN_EMAIL_CONFLICT(HttpStatus.CONFLICT, "이미 일반 회원가입으로 가입된 이메일입니다"),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/auction/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/auction/domain/auth/service/AuthService.java
@@ -33,7 +33,7 @@ public class AuthService {
 
     private static final String LOGIN_FAIL_PREFIX = "login:fail:";
     private static final int MAX_LOGIN_FAIL_COUNT = 5;
-    private static final long LOGIN_LOCK_DURATION = 5L;
+    private static final long LOGIN_LOCK_DURATION_MINUTES = 5L;
 
     @Value("${jwt.refreshExpire}")
     private long refreshTokenExpireTime;
@@ -123,8 +123,8 @@ public class AuthService {
 
     private void incrementFailCount(String failKey) {
         Long count = redisTemplate.opsForValue().increment(failKey);
-        if (count == 1) {
-            redisTemplate.expire(failKey, LOGIN_LOCK_DURATION, TimeUnit.MINUTES);
+        if (count != null && count == 1L) {
+            redisTemplate.expire(failKey, LOGIN_LOCK_DURATION_MINUTES, TimeUnit.MINUTES);
         }
     }
 }

--- a/src/main/java/com/example/auction/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/auction/domain/auth/service/AuthService.java
@@ -31,6 +31,10 @@ public class AuthService {
     private static final String REFRESH_TOKEN_PREFIX = "refresh:";
     private static final String BLACKLIST_PREFIX = "blacklist:";
 
+    private static final String LOGIN_FAIL_PREFIX = "login:fail:";
+    private static final int MAX_LOGIN_FAIL_COUNT = 5;
+    private static final long LOGIN_LOCK_DURATION = 5L;
+
     @Value("${jwt.refreshExpire}")
     private long refreshTokenExpireTime;
 
@@ -50,12 +54,25 @@ public class AuthService {
 
     @Transactional
     public AuthLoginResponse login(AuthLoginRequest request) {
+        String failKey = LOGIN_FAIL_PREFIX + request.email();
+
+        Number failCount = (Number) redisTemplate.opsForValue().get(failKey);
+        if (failCount != null && failCount.intValue() >= MAX_LOGIN_FAIL_COUNT) {
+            throw new ServiceErrorException(AuthErrorEnum.LOGIN_LOCKED);
+        }
+
         User user = userRepository.findByEmailAndDeletedFalse(request.email()).orElseThrow(
-                () -> new ServiceErrorException(AuthErrorEnum.INVALID_CREDENTIALS));
+                () -> {
+                    incrementFailCount(failKey);
+                    return new ServiceErrorException(AuthErrorEnum.INVALID_CREDENTIALS);
+                });
 
         if (user.getPassword() == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
+            incrementFailCount(failKey);
             throw new ServiceErrorException(AuthErrorEnum.INVALID_CREDENTIALS);
         }
+
+        redisTemplate.delete(failKey);
 
         String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());
@@ -102,5 +119,12 @@ public class AuthService {
                 remainingTtl,
                 TimeUnit.MILLISECONDS
         );
+    }
+
+    private void incrementFailCount(String failKey) {
+        Long count = redisTemplate.opsForValue().increment(failKey);
+        if (count == 1) {
+            redisTemplate.expire(failKey, LOGIN_LOCK_DURATION, TimeUnit.MINUTES);
+        }
     }
 }

--- a/src/main/java/com/example/auction/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/auction/domain/auth/service/AuthService.java
@@ -51,10 +51,10 @@ public class AuthService {
     @Transactional
     public AuthLoginResponse login(AuthLoginRequest request) {
         User user = userRepository.findByEmailAndDeletedFalse(request.email()).orElseThrow(
-                () -> new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND));
+                () -> new ServiceErrorException(AuthErrorEnum.INVALID_CREDENTIALS));
 
         if (user.getPassword() == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
-            throw new ServiceErrorException(AuthErrorEnum.INVALID_PASSWORD);
+            throw new ServiceErrorException(AuthErrorEnum.INVALID_CREDENTIALS);
         }
 
         String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());

--- a/src/main/java/com/example/auction/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/auction/domain/auth/service/AuthService.java
@@ -42,7 +42,7 @@ public class AuthService {
 
         String encodedPassword = passwordEncoder.encode(request.password());
 
-        User user = User.of(request.email(), encodedPassword, request.role());
+        User user = User.of(request.email(), encodedPassword);
         userRepository.save(user);
 
         return new AuthSignupResponse(user.getId(), user.getEmail(), user.getRole(), user.getCreatedAt());

--- a/src/main/java/com/example/auction/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/auction/domain/auth/service/CustomOAuth2UserService.java
@@ -54,7 +54,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         principalAttributes.put("userId", user.getId());
 
         return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority(user.getRole().name())),
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())),
                 principalAttributes,
                 authAttributes.getNameAttributeKey()
         );

--- a/src/main/java/com/example/auction/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/auction/domain/auth/service/CustomOAuth2UserService.java
@@ -78,7 +78,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         }
 
         try {
-            User newUser = User.ofSocial(authAttributes.getEmail(), UserRole.USER);
+            User newUser = User.ofSocial(authAttributes.getEmail());
             userRepository.save(newUser);
 
             UserSocialAccount newSocialAccount = UserSocialAccount.of(newUser.getId(), authAttributes.getProvider(), authAttributes.getProviderId());

--- a/src/main/java/com/example/auction/domain/category/exception/CategoryErrorEnum.java
+++ b/src/main/java/com/example/auction/domain/category/exception/CategoryErrorEnum.java
@@ -12,7 +12,9 @@ public enum CategoryErrorEnum implements ErrorEnumInterface {
     DUPLICATED_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리입니다"),
     CATEGORY_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "더 이상 하위 카테고리를 추가할 수 없습니다"),
     CATEGORY_CANNOT_BE_OWN_PARENT(HttpStatus.BAD_REQUEST, "자기 자신을 상위 카테고리로 지정할 수 없습니다"),
-    CATEGORY_CIRCULAR_REFERENCE(HttpStatus.BAD_REQUEST, "순환 참조가 발생하여 카테고리를 이동할 수 없습니다");
+    CATEGORY_CIRCULAR_REFERENCE(HttpStatus.BAD_REQUEST, "순환 참조가 발생하여 카테고리를 이동할 수 없습니다"),
+    SAME_NAME_CATEGORY(HttpStatus.BAD_REQUEST, "이미 동일한 이름입니다"),
+    SAME_LOCATION_CATEGORY(HttpStatus.BAD_REQUEST, "이미 동일한 위치입니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/auction/domain/category/service/CategoryService.java
+++ b/src/main/java/com/example/auction/domain/category/service/CategoryService.java
@@ -11,10 +11,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +41,10 @@ public class CategoryService {
         Category category = categoryRepository.findById(categoryId).orElseThrow(
                 () -> new ServiceErrorException(CategoryErrorEnum.CATEGORY_NOT_FOUND));
 
+        if (category.getName().equals(request.name())) {
+            throw new ServiceErrorException(CategoryErrorEnum.SAME_NAME_CATEGORY);
+        }
+
         if (category.getParentId() == null) {
             if (categoryRepository.existsByParentIdIsNullAndName(request.name())) {
                 throw new ServiceErrorException(CategoryErrorEnum.DUPLICATED_CATEGORY);
@@ -64,6 +65,10 @@ public class CategoryService {
     public CategoryMoveResponse moveCategory(Long categoryId, CategoryMoveRequest request) {
         Category category = categoryRepository.findById(categoryId).orElseThrow(
                 () -> new ServiceErrorException(CategoryErrorEnum.CATEGORY_NOT_FOUND));
+
+        if (Objects.equals(category.getParentId(), request.parentId())) {
+            throw new ServiceErrorException(CategoryErrorEnum.SAME_LOCATION_CATEGORY);
+        }
 
         if (request.parentId() != null && category.getId().equals(request.parentId())) {
             throw new ServiceErrorException(CategoryErrorEnum.CATEGORY_CANNOT_BE_OWN_PARENT);

--- a/src/main/java/com/example/auction/domain/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/example/auction/domain/review/dto/ReviewCreateRequest.java
@@ -3,12 +3,16 @@ package com.example.auction.domain.review.dto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record ReviewCreateRequest(
         @NotNull(message = "경매 식별자를 입력해주세요")
         Long auctionId,
+
         @Min(value = 1, message = "별점은 최소 1점입니다")
         @Max(value = 5, message = "별점은 최대 5점입니다")
         int score,
+
+        @Size(max = 500, message = "리뷰 내용은 500자 이하로 입력해주세요")
         String description
 ) {}

--- a/src/main/java/com/example/auction/domain/review/dto/ReviewModifyRequest.java
+++ b/src/main/java/com/example/auction/domain/review/dto/ReviewModifyRequest.java
@@ -2,10 +2,13 @@ package com.example.auction.domain.review.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 
 public record ReviewModifyRequest(
         @Min(value = 1, message = "별점은 최소 1점입니다")
         @Max(value = 5, message = "별점은 최대 5점입니다")
         Integer score,
+
+        @Size(max = 500, message = "리뷰 내용은 500자 이하로 입력해주세요")
         String description
 ) {}

--- a/src/main/java/com/example/auction/domain/review/dto/ReviewSearchCondition.java
+++ b/src/main/java/com/example/auction/domain/review/dto/ReviewSearchCondition.java
@@ -1,6 +1,7 @@
 package com.example.auction.domain.review.dto;
 
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
@@ -16,7 +17,8 @@ public class ReviewSearchCondition {
     private int page = 0;
 
     @Positive(message = "페이지 크기는 1 이상이어야 합니다")
-    private int size = 10;
+    @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다")
+    private int size = 20;
 
     private LocalDate startDate;
     private LocalDate endDate;

--- a/src/main/java/com/example/auction/domain/review/entity/Review.java
+++ b/src/main/java/com/example/auction/domain/review/entity/Review.java
@@ -33,6 +33,7 @@ public class Review extends ModifiableEntity {
     @Column(nullable = false)
     private int score;
 
+    @Column(length = 500)
     private String description;
 
     public static Review of(Long auctionId, Long reviewerId, Long revieweeId, int score, String description) {

--- a/src/main/java/com/example/auction/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/auction/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.example.auction.domain.user.dto.UserChangePasswordRequest;
 import com.example.auction.domain.user.dto.UserGetResponse;
 import com.example.auction.domain.user.dto.UserWithdrawResponse;
 import com.example.auction.domain.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -42,10 +43,12 @@ public class UserController {
 
     @DeleteMapping
     public ResponseEntity<BaseResponse<UserWithdrawResponse>> withdraw(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletRequest request
     ) {
+        String accessToken = (String) request.getAttribute("accessToken");
         Long userId = userDetails.getUserId();
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
-                HttpStatus.OK.name(), "탈퇴 요청 성공", userService.withdraw(userId)));
+                HttpStatus.OK.name(), "탈퇴 요청 성공", userService.withdraw(userId, accessToken)));
     }
 }

--- a/src/main/java/com/example/auction/domain/user/entity/User.java
+++ b/src/main/java/com/example/auction/domain/user/entity/User.java
@@ -32,21 +32,21 @@ public class User extends DeletableEntity {
     @Column(precision = 2, scale = 1)
     private BigDecimal rating;
 
-    public static User of(String email, String encodedPassword, UserRole role) {
+    public static User of(String email, String encodedPassword) {
         User user = new User();
         user.email = email;
         user.password = encodedPassword;
-        user.role = role;
+        user.role = UserRole.USER;
         user.rating = null;
 
         return user;
     }
 
-    public static User ofSocial(String email, UserRole role) {
+    public static User ofSocial(String email) {
         User user = new User();
         user.email = email;
         user.password = null;
-        user.role = role;
+        user.role = UserRole.USER;
         user.rating = null;
 
         return user;

--- a/src/main/java/com/example/auction/domain/user/service/UserService.java
+++ b/src/main/java/com/example/auction/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.auction.domain.user.service;
 
+import com.example.auction.common.config.security.JwtProvider;
 import com.example.auction.common.exception.ServiceErrorException;
 import com.example.auction.domain.auction.enums.AuctionStatus;
 import com.example.auction.domain.auction.repository.AuctionRepository;
@@ -13,11 +14,13 @@ import com.example.auction.domain.user.entity.User;
 import com.example.auction.domain.user.exception.UserErrorEnum;
 import com.example.auction.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +30,11 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final AuctionRepository auctionRepository;
     private final BidRepository bidRepository;
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:";
+    private static final String BLACKLIST_PREFIX = "blacklist:";
 
     @Transactional(readOnly = true)
     public UserGetResponse myPage(Long userId) {
@@ -59,7 +67,7 @@ public class UserService {
     }
 
     @Transactional
-    public UserWithdrawResponse withdraw(Long userId) {
+    public UserWithdrawResponse withdraw(Long userId, String accessToken) {
         User user = userRepository.findByIdAndDeletedFalse(userId).orElseThrow(
                 () -> new ServiceErrorException(UserErrorEnum.USER_NOT_FOUND));
 
@@ -72,6 +80,16 @@ public class UserService {
         }
 
         user.delete();
+
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
+
+        long remainingTtl = jwtProvider.getRemainingTtl(accessToken);
+        redisTemplate.opsForValue().set(
+                BLACKLIST_PREFIX + accessToken,
+                "withdraw",
+                remainingTtl,
+                TimeUnit.MILLISECONDS
+        );
 
         return new UserWithdrawResponse(
                 user.getId(),

--- a/src/test/java/com/example/auction/domain/auction/service/AuctionServiceCancelTest.java
+++ b/src/test/java/com/example/auction/domain/auction/service/AuctionServiceCancelTest.java
@@ -193,7 +193,7 @@ class AuctionServiceCancelTest {
     }
 
     private User createMockUser() {
-        User user = User.of("test@test.com", "encodedPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
         given(userRepository.findByIdAndDeletedFalse(user.getId())).willReturn(Optional.of(user));
 

--- a/src/test/java/com/example/auction/domain/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/example/auction/domain/auth/AuthIntegrationTest.java
@@ -123,9 +123,9 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("비밀번호가 일치하지 않습니다"));
+                .andExpect(jsonPath("$.message").value("이메일 또는 비밀번호가 일치하지 않습니다"));
     }
 
     @Test
@@ -138,9 +138,9 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isNotFound())
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("유저를 찾을 수 없습니다"));
+                .andExpect(jsonPath("$.message").value("이메일 또는 비밀번호가 일치하지 않습니다"));
     }
 
 

--- a/src/test/java/com/example/auction/domain/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/example/auction/domain/auth/AuthIntegrationTest.java
@@ -2,9 +2,7 @@ package com.example.auction.domain.auth;
 
 import com.example.auction.domain.auth.dto.AuthLoginRequest;
 import com.example.auction.domain.auth.dto.AuthSignupRequest;
-import com.example.auction.domain.user.enums.UserRole;
 import com.example.auction.testutils.BaseIntegrationTest;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +38,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        AuthSignupRequest signupRequest = new AuthSignupRequest("test@test.com", "password123", UserRole.USER);
+        AuthSignupRequest signupRequest = new AuthSignupRequest("test@test.com", "password123");
         mockMvc.perform(post("/api/auth/signup")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(signupRequest)));
@@ -64,7 +62,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
     @DisplayName("회원가입 성공")
     void signup_success() throws Exception {
         // given
-        AuthSignupRequest request = new AuthSignupRequest("signup@test.com", "password123", UserRole.USER);
+        AuthSignupRequest request = new AuthSignupRequest("signup@test.com", "password123");
 
         // when & then
         mockMvc.perform(post("/api/auth/signup")
@@ -80,7 +78,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
     @DisplayName("회원가입 실패 - 이메일 중복")
     void signup_fail_duplicatedEmail() throws Exception {
         // given
-        AuthSignupRequest request = new AuthSignupRequest("signup@test.com", "password123", UserRole.USER);
+        AuthSignupRequest request = new AuthSignupRequest("signup@test.com", "password123");
         mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)));

--- a/src/test/java/com/example/auction/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auth/controller/AuthControllerTest.java
@@ -60,7 +60,7 @@ class AuthControllerTest {
     @DisplayName("회원가입 성공")
     void signup_success() throws Exception {
         // given
-        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "password123", UserRole.USER);
+        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "password123");
         AuthSignupResponse response = new AuthSignupResponse(1L, "test@test.com", UserRole.USER, LocalDateTime.now());
 
         given(authService.signup(any(AuthSignupRequest.class))).willReturn(response);
@@ -79,7 +79,7 @@ class AuthControllerTest {
     @DisplayName("회원가입 실패 - 이메일 형식 불일치")
     void signup_fail_invalidEmail() throws Exception {
         // given
-        AuthSignupRequest request = new AuthSignupRequest("testEmail", "password123", UserRole.USER);
+        AuthSignupRequest request = new AuthSignupRequest("testEmail", "password123");
 
         // when & then
         mockMvc.perform(post("/api/auth/signup")
@@ -94,7 +94,7 @@ class AuthControllerTest {
     @DisplayName("회원가입 실패 - 비밀번호 8자 미만")
     void signup_fail_shortPassword() throws Exception {
         // given
-        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "pw123", UserRole.USER);
+        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "pw123");
 
         // when & then
         mockMvc.perform(post("/api/auth/signup")
@@ -103,21 +103,6 @@ class AuthControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.message").value("비밀번호는 8자 이상이어야 합니다"));
-    }
-
-    @Test
-    @DisplayName("회원가입 실패 - role 누락")
-    void signup_fail_nullRole() throws Exception {
-        // given
-        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "password123", null);
-
-        // when & then
-        mockMvc.perform(post("/api/auth/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("역할을 선택해주세요"));
     }
 
 

--- a/src/test/java/com/example/auction/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/auction/domain/auth/service/AuthServiceTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -130,6 +131,9 @@ class AuthServiceTest {
         AuthLoginRequest request = new AuthLoginRequest("test@test.com", "password123");
 
         given(userRepository.findByEmailAndDeletedFalse(request.email())).willReturn(Optional.empty());
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(anyString())).willReturn(null);
+        given(valueOperations.increment(anyString())).willReturn(1L);
 
         // when & then
         assertThatThrownBy(() -> authService.login(request))
@@ -147,6 +151,9 @@ class AuthServiceTest {
 
         given(userRepository.findByEmailAndDeletedFalse(request.email())).willReturn(Optional.of(user));
         given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(false);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(anyString())).willReturn(null);
+        given(valueOperations.increment(anyString())).willReturn(1L);
 
         // when & then
         assertThatThrownBy(() -> authService.login(request))

--- a/src/test/java/com/example/auction/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/auction/domain/auth/service/AuthServiceTest.java
@@ -134,7 +134,7 @@ class AuthServiceTest {
         // when & then
         assertThatThrownBy(() -> authService.login(request))
                 .isInstanceOf(ServiceErrorException.class)
-                .hasMessage(UserErrorEnum.USER_NOT_FOUND.getMessage());
+                .hasMessage(AuthErrorEnum.INVALID_CREDENTIALS.getMessage());
     }
 
     @Test
@@ -151,7 +151,7 @@ class AuthServiceTest {
         // when & then
         assertThatThrownBy(() -> authService.login(request))
                 .isInstanceOf(ServiceErrorException.class)
-                .hasMessage(AuthErrorEnum.INVALID_PASSWORD.getMessage());
+                .hasMessage(AuthErrorEnum.INVALID_CREDENTIALS.getMessage());
     }
 
 

--- a/src/test/java/com/example/auction/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/auction/domain/auth/service/AuthServiceTest.java
@@ -66,8 +66,8 @@ class AuthServiceTest {
     @DisplayName("회원가입 성공")
     void signup_success() {
         // given
-        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "password123", UserRole.USER);
-        User user = User.of(request.email(), "encodedPassword", request.role());
+        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "password123");
+        User user = User.of(request.email(), "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(userRepository.existsByEmail(request.email())).willReturn(false);
@@ -86,7 +86,7 @@ class AuthServiceTest {
     @DisplayName("회원가입 실패 - 이메일 중복")
     void signup_fail_duplicatedEmail() {
         // given
-        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "password123", UserRole.USER);
+        AuthSignupRequest request = new AuthSignupRequest("test@test.com", "password123");
 
         given(userRepository.existsByEmail(request.email())).willReturn(true);
 
@@ -106,7 +106,7 @@ class AuthServiceTest {
     void login_success() {
         //given
         AuthLoginRequest request = new AuthLoginRequest("test@test.com", "password123");
-        User user = User.of(request.email(), "encodedPassword", UserRole.USER);
+        User user = User.of(request.email(), "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(userRepository.findByEmailAndDeletedFalse(request.email())).willReturn(Optional.of(user));
@@ -142,7 +142,7 @@ class AuthServiceTest {
     void login_fail_invalidPassword() {
         // given
         AuthLoginRequest request = new AuthLoginRequest("test@test.com", "wrongPassword");
-        User user = User.of(request.email(), "encodedPassword", UserRole.USER);
+        User user = User.of(request.email(), "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(userRepository.findByEmailAndDeletedFalse(request.email())).willReturn(Optional.of(user));
@@ -164,7 +164,7 @@ class AuthServiceTest {
     void refreshToken_success() {
         // given
         String refreshToken = "refreshToken";
-        User user = User.of("test@test.com", "encodedPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(jwtProvider.validateRefreshToken(refreshToken)).willReturn(true);

--- a/src/test/java/com/example/auction/domain/bid/service/BidConcurrencyTest.java
+++ b/src/test/java/com/example/auction/domain/bid/service/BidConcurrencyTest.java
@@ -7,7 +7,6 @@ import com.example.auction.domain.bid.entity.Bid;
 import com.example.auction.domain.bid.repository.BidRepository;
 import com.example.auction.common.config.security.CustomUserDetails;
 import com.example.auction.domain.user.entity.User;
-import com.example.auction.domain.user.enums.UserRole;
 import com.example.auction.domain.user.repository.UserRepository;
 import com.example.auction.testutils.BaseIntegrationTest;
 
@@ -64,7 +63,7 @@ class BidConcurrencyTest extends BaseIntegrationTest {
     void setUp() {
         userIds.clear();
         for (long i = 1; i <= 50; i++) {
-            User user = User.of("user" + i + "@test.com", "password", UserRole.USER);
+            User user = User.of("user" + i + "@test.com", "password");
             User saved = userRepository.save(user);
             userIds.add(saved.getId()); // 실제 저장된 ID 기록
         }

--- a/src/test/java/com/example/auction/domain/category/CategoryIntegrationTest.java
+++ b/src/test/java/com/example/auction/domain/category/CategoryIntegrationTest.java
@@ -5,9 +5,10 @@ import com.example.auction.domain.auth.dto.AuthSignupRequest;
 import com.example.auction.domain.category.dto.CategoryCreateRequest;
 import com.example.auction.domain.category.dto.CategoryMoveRequest;
 import com.example.auction.domain.category.dto.CategoryRenameRequest;
+import com.example.auction.domain.user.entity.User;
 import com.example.auction.domain.user.enums.UserRole;
 import com.example.auction.testutils.BaseIntegrationTest;
-
+import com.example.auction.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +18,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.ObjectMapper;
@@ -41,13 +44,22 @@ public class CategoryIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     private String adminToken;
     private String userToken;
 
     @BeforeEach
     void setUp() throws Exception {
-        signup("admin@test.com", "password123", UserRole.ADMIN);
-        signup("user@test.com", "password123", UserRole.USER);
+        User admin = User.of("admin@test.com", passwordEncoder.encode("password123"));
+        ReflectionTestUtils.setField(admin, "role", UserRole.ADMIN);
+        userRepository.save(admin);
+
+        signup("user@test.com", "password123");
 
         adminToken = getAccessToken("admin@test.com", "password123");
         userToken = getAccessToken("user@test.com", "password123");
@@ -266,8 +278,8 @@ public class CategoryIntegrationTest extends BaseIntegrationTest {
     // 헬퍼 메서드
     // ========================
 
-    private void signup(String email, String password, UserRole role) throws Exception {
-        AuthSignupRequest request = new AuthSignupRequest(email, password, role);
+    private void signup(String email, String password) throws Exception {
+        AuthSignupRequest request = new AuthSignupRequest(email, password);
         mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/com/example/auction/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/example/auction/domain/category/service/CategoryServiceTest.java
@@ -224,6 +224,23 @@ class CategoryServiceTest {
     }
 
     @Test
+    @DisplayName("카테고리 이름 수정 실패 - 동일한 이름")
+    void renameCategory_fail_sameName() {
+        // given
+        Long categoryId = 1L;
+        Category category = Category.root("전자제품");
+        ReflectionTestUtils.setField(category, "id", categoryId);
+        CategoryRenameRequest request = new CategoryRenameRequest("전자제품");
+
+        given(categoryRepository.findById(categoryId)).willReturn(Optional.of(category));
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.renameCategory(categoryId, request))
+                .isInstanceOf(ServiceErrorException.class)
+                .hasMessage(CategoryErrorEnum.SAME_NAME_CATEGORY.getMessage());
+    }
+
+    @Test
     @DisplayName("카테고리 이름 수정 실패 - root 중복")
     void renameCategory_fail_rootDuplicated() {
         // given
@@ -335,6 +352,23 @@ class CategoryServiceTest {
         assertThatThrownBy(() -> categoryService.moveCategory(categoryId, request))
                 .isInstanceOf(ServiceErrorException.class)
                 .hasMessage(CategoryErrorEnum.CATEGORY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("카테고리 이동 실패 - 동일한 위치")
+    void moveCategory_fail_sameLocation() {
+        // given
+        Long categoryId = 1L;
+        Category category = Category.root("전자제품");
+        ReflectionTestUtils.setField(category, "id", categoryId);
+        CategoryMoveRequest request = new CategoryMoveRequest(null); // root → root
+
+        given(categoryRepository.findById(categoryId)).willReturn(Optional.of(category));
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.moveCategory(categoryId, request))
+                .isInstanceOf(ServiceErrorException.class)
+                .hasMessage(CategoryErrorEnum.SAME_LOCATION_CATEGORY.getMessage());
     }
 
     @Test

--- a/src/test/java/com/example/auction/domain/review/ReviewIntegrationTest.java
+++ b/src/test/java/com/example/auction/domain/review/ReviewIntegrationTest.java
@@ -286,7 +286,7 @@ public class ReviewIntegrationTest extends BaseIntegrationTest {
     // ========================
 
     private void signup(String email, String password) throws Exception {
-        AuthSignupRequest request = new AuthSignupRequest(email, password, UserRole.USER);
+        AuthSignupRequest request = new AuthSignupRequest(email, password);
         mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
@@ -189,6 +189,17 @@ class ReviewControllerTest {
     }
 
     @Test
+    @DisplayName("작성한 리뷰 목록 조회 실패 - size 100 초과")
+    void getWrittenReviewList_fail_sizeTooLarge() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/reviews/written")
+                        .param("size", "101"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지 크기는 100 이하여야 합니다"));
+    }
+
+    @Test
     @DisplayName("작성한 리뷰 목록 조회 실패 - startDate가 endDate 이후")
     void getWrittenReviewList_fail_invalidDateRange() throws Exception {
         // when & then
@@ -246,6 +257,17 @@ class ReviewControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.message").value("페이지 크기는 1 이상이어야 합니다"));
+    }
+
+    @Test
+    @DisplayName("받은 리뷰 목록 조회 실패 - size 100 초과")
+    void getReceivedReviewList_fail_sizeTooLarge() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/reviews/received")
+                        .param("size", "101"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지 크기는 100 이하여야 합니다"));
     }
 
     @Test

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
@@ -125,6 +125,21 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.message").value("별점은 최대 5점입니다"));
     }
 
+    @Test
+    @DisplayName("리뷰 작성 실패 - 설명 500자 초과")
+    void createReview_fail_descriptionTooLong() throws Exception {
+        // given
+        ReviewCreateRequest request = new ReviewCreateRequest(1L, 5, "a".repeat(501));
+
+        // when & then
+        mockMvc.perform(post("/api/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("리뷰 내용은 500자 이하로 입력해주세요"));
+    }
+
 
     // ========================
     // 작성한 리뷰 목록 조회
@@ -321,6 +336,21 @@ class ReviewControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.message").value("별점은 최대 5점입니다"));
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 설명 500자 초과")
+    void modifyReview_fail_descriptionTooLong() throws Exception {
+        // given
+        ReviewModifyRequest request = new ReviewModifyRequest(null, "a".repeat(501));
+
+        // when & then
+        mockMvc.perform(patch("/api/reviews/{reviewId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("리뷰 내용은 500자 이하로 입력해주세요"));
     }
 
 

--- a/src/test/java/com/example/auction/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/auction/domain/review/service/ReviewServiceTest.java
@@ -10,7 +10,6 @@ import com.example.auction.domain.review.entity.Review;
 import com.example.auction.domain.review.exception.ReviewErrorEnum;
 import com.example.auction.domain.review.repository.ReviewRepository;
 import com.example.auction.domain.user.entity.User;
-import com.example.auction.domain.user.enums.UserRole;
 import com.example.auction.domain.user.exception.UserErrorEnum;
 import com.example.auction.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -87,7 +86,7 @@ class ReviewServiceTest {
         AuctionResult auctionResult = AuctionResult.of(BigDecimal.valueOf(1000), auctionId, buyerId, sellerId, bidId);
         ReflectionTestUtils.setField(auctionResult, "id", 1L);
 
-        User reviewee = User.of("seller@test.com", "encodedPassword", UserRole.USER);
+        User reviewee = User.of("seller@test.com", "encodedPassword");
         ReflectionTestUtils.setField(reviewee, "id", sellerId);
 
         given(reviewRepository.existsByAuctionIdAndReviewerId(auctionId, buyerId)).willReturn(false);
@@ -195,7 +194,7 @@ class ReviewServiceTest {
 
         AuctionResult auctionResult = AuctionResult.of(BigDecimal.valueOf(1000), auctionId, buyerId, sellerId, bidId);
 
-        User reviewee = User.of("seller@test.com", "encodedPassword", UserRole.USER);
+        User reviewee = User.of("seller@test.com", "encodedPassword");
         ReflectionTestUtils.setField(reviewee, "id", sellerId);
 
         given(reviewRepository.existsByAuctionIdAndReviewerId(auctionId, buyerId)).willReturn(false);
@@ -395,7 +394,7 @@ class ReviewServiceTest {
         Review review = Review.of(10L, userId, 2L, 5, "좋아요");
         ReflectionTestUtils.setField(review, "id", reviewId);
 
-        User reviewee = User.of("seller@test.com", "encodedPassword", UserRole.USER);
+        User reviewee = User.of("seller@test.com", "encodedPassword");
         ReflectionTestUtils.setField(reviewee, "id", 2L);
 
         given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
@@ -500,7 +499,7 @@ class ReviewServiceTest {
         Review review = Review.of(10L, userId, 2L, 5, "좋아요");
         ReflectionTestUtils.setField(review, "id", reviewId);
 
-        User reviewee = User.of("seller@test.com", "encodedPassword", UserRole.USER);
+        User reviewee = User.of("seller@test.com", "encodedPassword");
         ReflectionTestUtils.setField(reviewee, "id", 2L);
         ReflectionTestUtils.setField(reviewee, "rating", BigDecimal.valueOf(3.0));
 
@@ -526,7 +525,7 @@ class ReviewServiceTest {
         Review review = Review.of(10L, userId, 2L, 5, "좋아요");
         ReflectionTestUtils.setField(review, "id", reviewId);
 
-        User reviewee = User.of("seller@test.com", "encodedPassword", UserRole.USER);
+        User reviewee = User.of("seller@test.com", "encodedPassword");
         ReflectionTestUtils.setField(reviewee, "id", 2L);
         ReflectionTestUtils.setField(reviewee, "rating", BigDecimal.valueOf(5.0));
 
@@ -552,7 +551,7 @@ class ReviewServiceTest {
         Review review = Review.of(10L, userId, 2L, 5, "좋아요");
         ReflectionTestUtils.setField(review, "id", reviewId);
 
-        User reviewee = User.of("seller@test.com", "encodedPassword", UserRole.USER);
+        User reviewee = User.of("seller@test.com", "encodedPassword");
         ReflectionTestUtils.setField(reviewee, "id", 2L);
         ReflectionTestUtils.setField(reviewee, "deleted", true);
 

--- a/src/test/java/com/example/auction/domain/user/UserIntegrationTest.java
+++ b/src/test/java/com/example/auction/domain/user/UserIntegrationTest.java
@@ -44,7 +44,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
     @BeforeEach
     void setUp() throws Exception {
         // 회원가입
-        AuthSignupRequest signupRequest = new AuthSignupRequest("test@test.com", "password123", UserRole.USER);
+        AuthSignupRequest signupRequest = new AuthSignupRequest("test@test.com", "password123");
         mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(signupRequest)));

--- a/src/test/java/com/example/auction/domain/user/UserIntegrationTest.java
+++ b/src/test/java/com/example/auction/domain/user/UserIntegrationTest.java
@@ -3,7 +3,6 @@ package com.example.auction.domain.user;
 import com.example.auction.domain.auth.dto.AuthLoginRequest;
 import com.example.auction.domain.auth.dto.AuthSignupRequest;
 import com.example.auction.domain.user.dto.UserChangePasswordRequest;
-import com.example.auction.domain.user.enums.UserRole;
 import com.example.auction.testutils.BaseIntegrationTest;
 
 import org.junit.jupiter.api.AfterEach;
@@ -151,7 +150,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("유저를 찾을 수 없습니다"));
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("이메일 또는 비밀번호가 일치하지 않습니다"));
     }
 }

--- a/src/test/java/com/example/auction/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/auction/domain/user/controller/UserControllerTest.java
@@ -25,8 +25,10 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -141,14 +143,17 @@ class UserControllerTest {
                 1L, "test@test.com", UserRole.USER, LocalDateTime.now(), LocalDateTime.now()
         );
 
-        given(userService.withdraw(1L)).willReturn(response);
+        given(userService.withdraw(eq(1L), any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(delete("/api/users"))
+        mockMvc.perform(delete("/api/users")
+                        .requestAttr("accessToken", "accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("탈퇴 요청 성공"))
                 .andExpect(jsonPath("$.data.email").value("test@test.com"))
                 .andExpect(jsonPath("$.data.role").value("USER"));
+
+        verify(userService).withdraw(eq(1L), eq("accessToken"));
     }
 }

--- a/src/test/java/com/example/auction/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/auction/domain/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.auction.domain.user.service;
 
+import com.example.auction.common.config.security.JwtProvider;
 import com.example.auction.common.exception.ServiceErrorException;
 import com.example.auction.domain.auction.repository.AuctionRepository;
 import com.example.auction.domain.auth.exception.AuthErrorEnum;
@@ -17,6 +18,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -43,6 +46,15 @@ class UserServiceTest {
 
     @Mock
     private BidRepository bidRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
 
     // ========================
     // 마이페이지 조회
@@ -154,29 +166,35 @@ class UserServiceTest {
     @DisplayName("회원 탈퇴 성공")
     void withdraw_success() {
         // given
+        String accessToken = "accessToken";
         User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
+        long remainingTtl = 300000L;
 
         given(userRepository.findByIdAndDeletedFalse(1L)).willReturn(Optional.of(user));
         given(auctionRepository.existsByUserIdAndStatusIn(any(), any())).willReturn(false);
         given(bidRepository.existsByUserIdAndStatus(any(), any())).willReturn(false);
+        given(jwtProvider.getRemainingTtl(accessToken)).willReturn(remainingTtl);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
         // when
-        UserWithdrawResponse response = userService.withdraw(1L);
+        UserWithdrawResponse response = userService.withdraw(1L, accessToken);
 
         // then
         assertThat(response.email()).isEqualTo("test@test.com");
         assertThat(response.role()).isEqualTo(UserRole.USER);
+        assertThat(response.deletedAt()).isNotNull();
     }
 
     @Test
     @DisplayName("회원 탈퇴 실패 - 유저 없음")
     void withdraw_fail_userNotFound() {
         // given
+        String accessToken = "accessToken";
         given(userRepository.findByIdAndDeletedFalse(1L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.withdraw(1L))
+        assertThatThrownBy(() -> userService.withdraw(1L, accessToken))
                 .isInstanceOf(ServiceErrorException.class)
                 .hasMessage(UserErrorEnum.USER_NOT_FOUND.getMessage());
     }
@@ -185,6 +203,7 @@ class UserServiceTest {
     @DisplayName("회원 탈퇴 실패 - 진행 중인 경매 있음")
     void withdraw_fail_hasActiveAuction() {
         // given
+        String accessToken = "accessToken";
         User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -192,7 +211,7 @@ class UserServiceTest {
         given(auctionRepository.existsByUserIdAndStatusIn(any(), any())).willReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> userService.withdraw(1L))
+        assertThatThrownBy(() -> userService.withdraw(1L, accessToken))
                 .isInstanceOf(ServiceErrorException.class)
                 .hasMessage(UserErrorEnum.HAS_ACTIVE_AUCTION.getMessage());
     }
@@ -201,6 +220,7 @@ class UserServiceTest {
     @DisplayName("회원 탈퇴 실패 - 진행 중인 입찰 있음")
     void withdraw_fail_hasActiveBid() {
         // given
+        String accessToken = "accessToken";
         User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -209,7 +229,7 @@ class UserServiceTest {
         given(bidRepository.existsByUserIdAndStatus(any(), any())).willReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> userService.withdraw(1L))
+        assertThatThrownBy(() -> userService.withdraw(1L, accessToken))
                 .isInstanceOf(ServiceErrorException.class)
                 .hasMessage(UserErrorEnum.HAS_ACTIVE_BID.getMessage());
     }

--- a/src/test/java/com/example/auction/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/auction/domain/user/service/UserServiceTest.java
@@ -52,7 +52,7 @@ class UserServiceTest {
     @DisplayName("마이페이지 조회 성공")
     void myPage_success() {
         // given
-        User user = User.of("test@test.com", "encodedPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(userRepository.findByIdAndDeletedFalse(1L)).willReturn(Optional.of(user));
@@ -86,7 +86,7 @@ class UserServiceTest {
     @DisplayName("비밀번호 변경 성공")
     void changePassword_success() {
         // given
-        User user = User.of("test@test.com", "encodedOldPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedOldPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
         UserChangePasswordRequest request = new UserChangePasswordRequest("oldPassword", "newPassword");
 
@@ -116,7 +116,7 @@ class UserServiceTest {
     @DisplayName("비밀번호 변경 실패 - 새 비밀번호가 기존과 동일")
     void changePassword_fail_sameAsOldPassword() {
         // given
-        User user = User.of("test@test.com", "encodedOldPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedOldPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
         UserChangePasswordRequest request = new UserChangePasswordRequest("samePassword", "samePassword");
 
@@ -132,7 +132,7 @@ class UserServiceTest {
     @DisplayName("비밀번호 변경 실패 - 기존 비밀번호 불일치")
     void changePassword_fail_invalidOldPassword() {
         // given
-        User user = User.of("test@test.com", "encodedOldPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedOldPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
         UserChangePasswordRequest request = new UserChangePasswordRequest("wrongOldPassword", "newPassword");
 
@@ -154,7 +154,7 @@ class UserServiceTest {
     @DisplayName("회원 탈퇴 성공")
     void withdraw_success() {
         // given
-        User user = User.of("test@test.com", "encodedPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(userRepository.findByIdAndDeletedFalse(1L)).willReturn(Optional.of(user));
@@ -185,7 +185,7 @@ class UserServiceTest {
     @DisplayName("회원 탈퇴 실패 - 진행 중인 경매 있음")
     void withdraw_fail_hasActiveAuction() {
         // given
-        User user = User.of("test@test.com", "encodedPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(userRepository.findByIdAndDeletedFalse(1L)).willReturn(Optional.of(user));
@@ -201,7 +201,7 @@ class UserServiceTest {
     @DisplayName("회원 탈퇴 실패 - 진행 중인 입찰 있음")
     void withdraw_fail_hasActiveBid() {
         // given
-        User user = User.of("test@test.com", "encodedPassword", UserRole.USER);
+        User user = User.of("test@test.com", "encodedPassword");
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(userRepository.findByIdAndDeletedFalse(1L)).willReturn(Optional.of(user));


### PR DESCRIPTION
## 📝 작업 내용
### Auth / User
- 회원 탈퇴 시 access token 블랙리스트 등록 및 refresh token 삭제 처리
- 로그인 실패 응답을 `INVALID_CREDENTIALS`로 통일하여 계정 존재 여부 노출 방지
- Redis 기반 로그인 실패 횟수 제한 추가 (5회 실패 시 5분 잠금, fixed window)
- OAuth 사용자 권한에 ROLE_ prefix 추가하여 JWT 권한 표현과 통일

### Review
- 리뷰 목록 엔드포인트(`/witten`, `/received`)에 명시적 authenticated() 규칙 추가 - `/api/reviews/{reviewId}` permitAll 패턴과 충돌 방지
- 리뷰 설명 최대 길이 500자 검증 추가(`@Size`, `@Column(length=500)`)
- 리뷰 조회 페이지 크기 상한 100 및 기본값 20으로 설정

### Category
- 동일 이름으로 rename, 동일 위치로 move 시도 시 `SAME_NAME_CATEGORY` / `SAME_LOCATION_CATEGORY` 명시적 예외 처리 추가

### 수정하지 않은 항목
Redis 장애 시 인증 fail-closed 유지
- Redis 장애 시 인증이 성공되면 경매 서비스 특성상 실제 피해로 이어질 수 있어 보안 우선 정책으로 유지

탈퇴 후 동일 이메일 재가입 영구 차단
- existsByEmail이 삭제된 사용자를 포함하는 것은 의도된 흐름

카테고리 root 중복 DB unique 제약 미적용
- 애플리케이션 체크만 있으므로 동시 생성 경합에 취약하나, 추후 init.sql 작성 시 유니크 인덱스 추가하여 반영 예정

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 로그인 실패 횟수 초과 시 일시적 계정 잠금 기능 추가

* **버그 수정**
  * 리뷰 작성/수정 시 내용 길이를 500자 이하로 제한
  * 카테고리를 동일한 이름/위치로 변경하는 것 방지

* **보안 강화**
  * 리뷰 조회 API에 사용자 인증 필수로 변경
  * 로그인 오류 메시지 통일로 보안 개선
  * 계정 탈퇴 시 토큰 무효화 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->