### PR TITLE
[FEAT] Grafana Cloud → Amazon Managed Prometheus 마이그레이션

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -200,9 +200,7 @@ jobs:
           AWS_ECS_CLUSTER_ARN: ${{ secrets.AWS_ECS_CLUSTER_ARN }}
 
           ALLOY_ECR_REPOSITORY: ${{ secrets.ALLOY_ECR_REPOSITORY }}
-          GRAFANA_CLOUD_PUSH_URL: ${{ secrets.GRAFANA_CLOUD_PUSH_URL }}
-          GRAFANA_CLOUD_USERNAME: ${{ secrets.GRAFANA_CLOUD_USERNAME }}
-          GRAFANA_CLOUD_API_KEY: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
+          AMP_REMOTE_WRITE_URL: ${{ secrets.AMP_REMOTE_WRITE_URL }}
 
         run: |
           set -euo pipefail
@@ -220,9 +218,7 @@ jobs:
             | sed -e "s|__ECR_URI__|${ECR_URI}|g" \
             | sed -e "s|__AWS_REGION__|${AWS_REGION}|g" \
             | sed -e "s|__ALLOY_ECR_URI__|${ALLOY_URI}|g" \
-            | sed -e "s|__GRAFANA_CLOUD_PUSH_URL__|${GRAFANA_CLOUD_PUSH_URL}|g" \
-            | sed -e "s|__GRAFANA_CLOUD_USERNAME__|${GRAFANA_CLOUD_USERNAME}|g" \
-            | sed -e "s|__GRAFANA_CLOUD_API_KEY__|${GRAFANA_CLOUD_API_KEY}|g" \
+            | sed -e "s|__AMP_REMOTE_WRITE_URL__|${AMP_REMOTE_WRITE_URL}|g" \
           )
 
           echo "$TASK_DEF" > task-definition-out.json

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -2,15 +2,14 @@ prometheus.scrape "spring" {
   targets         = [{"__address__" = "localhost:9001"}]
   metrics_path    = "/actuator/prometheus"
   scrape_interval = "15s"
-  forward_to      = [prometheus.remote_write.grafanacloud.receiver]
+  forward_to      = [prometheus.remote_write.amp.receiver]
 }
 
-prometheus.remote_write "grafanacloud" {
+prometheus.remote_write "amp" {
   endpoint {
-    url = env("GRAFANA_CLOUD_PUSH_URL")
-    basic_auth {
-      username = env("GRAFANA_CLOUD_USERNAME")
-      password = env("GRAFANA_CLOUD_API_KEY")
+    url = env("AMP_REMOTE_WRITE_URL")
+    sigv4 {
+      region = "ap-northeast-2"
     }
   }
 }

--- a/task_definition.json
+++ b/task_definition.json
@@ -64,16 +64,8 @@
             "essential": false,
             "environment": [
                 {
-                    "name": "GRAFANA_CLOUD_PUSH_URL",
-                    "value": "__GRAFANA_CLOUD_PUSH_URL__"
-                },
-                {
-                    "name": "GRAFANA_CLOUD_USERNAME",
-                    "value": "__GRAFANA_CLOUD_USERNAME__"
-                },
-                {
-                    "name": "GRAFANA_CLOUD_API_KEY",
-                    "value": "__GRAFANA_CLOUD_API_KEY__"
+                    "name": "AMP_REMOTE_WRITE_URL",
+                    "value": "__AMP_REMOTE_WRITE_URL__"
                 }
             ],
             "logConfiguration": {

--- a/task_definition.json
+++ b/task_definition.json
@@ -77,6 +77,16 @@
                     "awslogs-stream-prefix": "alloy"
                 }
             },
+            "healthCheck": {
+                "command": [
+                    "CMD-SHELL",
+                    "wget --quiet --tries=1 --spider http://localhost:12345/-/ready || exit 1"
+                ],
+                "interval": 15,
+                "timeout": 5,
+                "retries": 3,
+                "startPeriod": 30
+            },
             "systemControls": []
         }
     ],


### PR DESCRIPTION
## 📝 작업 내용
- Grafana Cloud 외부 의존성 제거 — 메트릭 수집을 AWS 내부(AMP)로 전환


## 🔗 관련 이슈 (Related Issues)
Closes #

## ✅ 체크리스트 (Checklist)
- [X] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [X] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [ ] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 메트릭 송신 대상을 Grafana Cloud에서 AWS AMP(Amazon Managed Prometheus)로 변경했습니다.
  * 메트릭 인증 방식을 기본 인증에서 AWS SigV4 기반 서명으로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->