### PR TITLE
[FEAT] 경매 검색에 Elasticsearch를 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     // testcontainers
     testImplementation platform('org.testcontainers:testcontainers-bom:2.0.5')
     testImplementation "org.testcontainers:testcontainers-postgresql"
+    testImplementation "org.testcontainers:testcontainers-elasticsearch"
     testImplementation "com.redis:testcontainers-redis:2.2.4"
 
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
     // AWS EventBridge Scheduler
     implementation 'software.amazon.awssdk:scheduler:2.42.20'
 
+    // Elasticsearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
     // testcontainers
     testImplementation platform('org.testcontainers:testcontainers-bom:2.0.5')
     testImplementation "org.testcontainers:testcontainers-postgresql"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      ELASTICSEARCH_USERNAME: elastic
       ELASTICSEARCH_PASSWORD: ${ELASTICSEARCH_PASSWORD}
       ELASTICSEARCH_URIS: ${ELASTICSEARCH_URIS}
       ADMIN_SECRET_KEY: ${ADMIN_SECRET_KEY}
@@ -162,6 +163,8 @@ services:
       xpack.security.enabled: true
       xpack.security.http.ssl.enabled: false
       xpack.security.transport.ssl.enabled: false
+      # elasticsearch가 쓸 수 있는 최대 ram을 2GB 로 한정
+      ES_JAVA_OPTS: "-Xmx2g"
       ELASTIC_PASSWORD: ${ELASTICSEARCH_PASSWORD}
     ports:
       - "9200:9200"
@@ -191,7 +194,7 @@ services:
       ELASTICSEARCH_PASSWORD: kibana
     command: >
       bash -c "
-        curl -u elastic:${ELASTICSEARCH_PASSWORD} -X POST http://auction-elasticsearch:9200/_security/user/kibana_system/_password -H 'Content-Type: application/json' -d '{\"password\": \"kibana\"}' ; /usr/local/bin/kibana-docker
+        curl -u elastic:${ELASTICSEARCH_PASSWORD} -X POST http://auction-elasticsearch:9200/_security/user/kibana_system/_password -H 'Content-Type: application/json' -d '{\"password\": \"kibana\"}' && /usr/local/bin/kibana-docker
       "
     depends_on:
       elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      ELASTICSEARCH_PASSWORD: ${ELASTICSEARCH_PASSWORD}
       ELASTICSEARCH_URIS: ${ELASTICSEARCH_URIS}
       ADMIN_SECRET_KEY: ${ADMIN_SECRET_KEY}
     healthcheck:
@@ -71,6 +72,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      elasticsearch:
         condition: service_healthy
 
   notification:
@@ -156,9 +159,19 @@ services:
     container_name: auction-elasticsearch
     environment:
       discovery.type: single-node
-      xpack.security.enabled: false
+      xpack.security.enabled: true
+      xpack.security.http.ssl.enabled: false
+      xpack.security.transport.ssl.enabled: false
+      ELASTIC_PASSWORD: ${ELASTICSEARCH_PASSWORD}
     ports:
       - "9200:9200"
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -u elastic:${ELASTICSEARCH_PASSWORD} http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     command: >
       bash -c "
         if [ ! -d /usr/share/elasticsearch/plugins/analysis-nori ]; then
@@ -167,18 +180,20 @@ services:
         /usr/local/bin/docker-entrypoint.sh
       "
 
-  kibana:
-    image: kibana:9.3.3
-    container_name: auction-kibana
-    ports:
-      - "5601:5601"
-    environment:
-      ELASTICSEARCH_HOSTS: http://auction-elasticsearch:9200
-    depends_on:
-      - elasticsearch
+  # TODO: kibana랑 elastic 같이 돌리는 방법 알아보기
+  # kibana:
+  #   image: kibana:9.3.3
+  #   container_name: auction-kibana
+  #   ports:
+  #     - "5601:5601"
+  #   environment:
+  #     ELASTICSEARCH_HOSTS: http://auction-elasticsearch:9200
+  #   depends_on:
+  #     - elasticsearch
 
 volumes:
   postgres-data:
   influxdb-data:
   grafana-data:
   prometheus-data:
+  elasticsearch-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,16 +180,22 @@ services:
         /usr/local/bin/docker-entrypoint.sh
       "
 
-  # TODO: kibana랑 elastic 같이 돌리는 방법 알아보기
-  # kibana:
-  #   image: kibana:9.3.3
-  #   container_name: auction-kibana
-  #   ports:
-  #     - "5601:5601"
-  #   environment:
-  #     ELASTICSEARCH_HOSTS: http://auction-elasticsearch:9200
-  #   depends_on:
-  #     - elasticsearch
+  kibana:
+    image: kibana:9.3.3
+    container_name: auction-kibana
+    ports:
+      - "5601:5601"
+    environment:
+      ELASTICSEARCH_HOSTS: http://auction-elasticsearch:9200
+      ELASTICSEARCH_USERNAME: kibana_system
+      ELASTICSEARCH_PASSWORD: kibana
+    command: >
+      bash -c "
+        curl -u elastic:${ELASTICSEARCH_PASSWORD} -X POST http://auction-elasticsearch:9200/_security/user/kibana_system/_password -H 'Content-Type: application/json' -d '{\"password\": \"kibana\"}' ; /usr/local/bin/kibana-docker
+      "
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      ELASTICSEARCH_URIS: ${ELASTICSEARCH_URIS}
       ADMIN_SECRET_KEY: ${ADMIN_SECRET_KEY}
     healthcheck:
       test: "curl --fail --silent localhost:8080/health || exit 1"
@@ -124,7 +125,6 @@ services:
     depends_on:
       - prometheus
 
-
   influxdb:
     image: influxdb:1.8
     container_name: auction-influxdb
@@ -150,6 +150,32 @@ services:
         condition: service_started
       prometheus:
         condition: service_healthy
+
+  elasticsearch:
+    image: elasticsearch:9.3.3
+    container_name: auction-elasticsearch
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: false
+    ports:
+      - "9200:9200"
+    command: >
+      bash -c "
+        if [ ! -d /usr/share/elasticsearch/plugins/analysis-nori ]; then
+          bin/elasticsearch-plugin install analysis-nori --batch;
+        fi &&
+        /usr/local/bin/docker-entrypoint.sh
+      "
+
+  kibana:
+    image: kibana:9.3.3
+    container_name: auction-kibana
+    ports:
+      - "5601:5601"
+    environment:
+      ELASTICSEARCH_HOSTS: http://auction-elasticsearch:9200
+    depends_on:
+      - elasticsearch
 
 volumes:
   postgres-data:

--- a/src/main/java/com/example/auction/common/config/AsyncConfig.java
+++ b/src/main/java/com/example/auction/common/config/AsyncConfig.java
@@ -1,0 +1,17 @@
+package com.example.auction.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "executorWithVT")
+    public Executor asyncExecutorWithVT() {
+        return Executors.newVirtualThreadPerTaskExecutor();
+    }
+}

--- a/src/main/java/com/example/auction/domain/auction/dto/AuctionSearchCondition.java
+++ b/src/main/java/com/example/auction/domain/auction/dto/AuctionSearchCondition.java
@@ -48,4 +48,9 @@ public class AuctionSearchCondition {
             this.status.addAll(Arrays.asList(statuses));
         }
     }
+
+    public String toLogString() {
+        return "keyword=\"%s\", maxPriceMin=%s, maxPriceMax=%s, status=%s, categoryId=%s, page=%s, pageSize=%s"
+            .formatted(this.keyword, this.maxPriceMin, this.maxPriceMax, this.status, this.categoryId, this.page, this.pageSize);
+    }
 }

--- a/src/main/java/com/example/auction/domain/auction/dto/GetManyAuctionsResponse.java
+++ b/src/main/java/com/example/auction/domain/auction/dto/GetManyAuctionsResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 
 import com.example.auction.domain.auction.entity.Auction;
 import com.example.auction.domain.auction.enums.AuctionStatus;
+import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -49,6 +50,28 @@ public class GetManyAuctionsResponse {
             auction.getCategoryId(),
 
             auction.getCreatedAt()
+        );
+    }
+
+    public static GetManyAuctionsResponse from(AuctionSearchResult searchResult) {
+        return new GetManyAuctionsResponse(
+            searchResult.id(),
+
+            searchResult.userId(),
+
+            searchResult.maxPrice(),
+
+            searchResult.itemName(),
+
+            searchResult.status(),
+
+            searchResult.startedAt(),
+            searchResult.endedAt(),
+            searchResult.cancelledAt(),
+
+            searchResult.categoryId(),
+
+            searchResult.createdAt()
         );
     }
 }

--- a/src/main/java/com/example/auction/domain/auction/search/document/AuctionDocument.java
+++ b/src/main/java/com/example/auction/domain/auction/search/document/AuctionDocument.java
@@ -9,7 +9,6 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-import com.example.auction.domain.auction.entity.Auction;
 import com.example.auction.domain.auction.enums.AuctionStatus;
 import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
 

--- a/src/main/java/com/example/auction/domain/auction/search/document/AuctionDocument.java
+++ b/src/main/java/com/example/auction/domain/auction/search/document/AuctionDocument.java
@@ -17,7 +17,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Document(indexName = "auction-index")
+// 인덱스 이름이 좀 이상한 이유는 현재 spring한테 index중 auction- 으로 시작 하는 index만 쓰고 읽을 권한이 있기 때문입니다.
+// 
+// auction-notification, auction-user등 추가로 index가 만들어지면 덜 이상할 것입니다.
+@Document(indexName = "auction-auction")
 @NoArgsConstructor
 public class AuctionDocument {
     @Id

--- a/src/main/java/com/example/auction/domain/auction/search/document/AuctionDocument.java
+++ b/src/main/java/com/example/auction/domain/auction/search/document/AuctionDocument.java
@@ -1,0 +1,79 @@
+package com.example.auction.domain.auction.search.document;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import com.example.auction.domain.auction.entity.Auction;
+import com.example.auction.domain.auction.enums.AuctionStatus;
+import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Document(indexName = "auction-index")
+@NoArgsConstructor
+public class AuctionDocument {
+    @Id
+    private Long id;
+
+    private Long userId;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String description;
+
+    private BigDecimal maxPrice;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String itemName;
+
+    @Field(type = FieldType.Keyword)
+    private AuctionStatus status;
+
+    @Field(type = FieldType.Date, format=DateFormat.date_hour_minute_second_fraction)
+    private LocalDateTime startedAt;
+
+    @Field(type = FieldType.Date, format=DateFormat.date_hour_minute_second_fraction)
+    private LocalDateTime endedAt;
+
+    @Field(type = FieldType.Date, format=DateFormat.date_hour_minute_second_fraction)
+    private LocalDateTime cancelledAt;
+
+    private Long categoryId;
+
+    @Field(type = FieldType.Date, format=DateFormat.date_hour_minute_second_fraction)
+    private LocalDateTime createdAt;
+
+    public static AuctionDocument from(AuctionCreatedDocument dto) {
+        AuctionDocument auctionDoc = new AuctionDocument();
+
+        auctionDoc.id = dto.id();
+
+        auctionDoc.userId = dto.userId();
+
+        auctionDoc.description = dto.description();
+
+        auctionDoc.maxPrice = dto.maxPrice();
+
+        auctionDoc.itemName = dto.itemName();
+
+        auctionDoc.status = dto.status();
+
+        auctionDoc.startedAt = dto.startedAt();
+        auctionDoc.endedAt = dto.endedAt();
+        auctionDoc.cancelledAt = dto.cancelledAt();
+
+        auctionDoc.categoryId = dto.categoryId();
+
+        auctionDoc.createdAt = dto.createdAt();
+
+        return auctionDoc;
+    }
+}
+

--- a/src/main/java/com/example/auction/domain/auction/search/dto/AuctionCreatedDocument.java
+++ b/src/main/java/com/example/auction/domain/auction/search/dto/AuctionCreatedDocument.java
@@ -1,0 +1,57 @@
+package com.example.auction.domain.auction.search.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.example.auction.domain.auction.entity.Auction;
+import com.example.auction.domain.auction.enums.AuctionStatus;
+
+public record AuctionCreatedDocument(
+    Long id,
+
+    Long userId,
+
+    String description,
+
+    BigDecimal maxPrice,
+
+    String itemName,
+
+    AuctionStatus status,
+
+    LocalDateTime startedAt,
+
+    LocalDateTime endedAt,
+
+    LocalDateTime cancelledAt,
+
+    Long categoryId,
+
+    LocalDateTime createdAt
+) {
+    public static AuctionCreatedDocument from(Auction auction){
+        return new AuctionCreatedDocument(
+            auction.getId(),
+
+            auction.getUserId(),
+
+            auction.getDescription(),
+
+            auction.getMaxPrice(),
+
+            auction.getItemName(),
+
+            auction.getStatus(),
+
+            auction.getStartedAt(),
+
+            auction.getEndedAt(),
+
+            auction.getCancelledAt(),
+
+            auction.getCategoryId(),
+
+            auction.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/auction/domain/auction/search/dto/AuctionSearchResult.java
+++ b/src/main/java/com/example/auction/domain/auction/search/dto/AuctionSearchResult.java
@@ -1,0 +1,54 @@
+package com.example.auction.domain.auction.search.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.example.auction.domain.auction.entity.Auction;
+import com.example.auction.domain.auction.enums.AuctionStatus;
+import com.example.auction.domain.auction.search.document.AuctionDocument;
+
+public record AuctionSearchResult (
+    Long id,
+    Long userId,
+    String description,
+    BigDecimal maxPrice,
+    String itemName,
+    AuctionStatus status,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt,
+    LocalDateTime cancelledAt,
+    Long categoryId,
+    LocalDateTime createdAt
+) {
+    public static AuctionSearchResult from(Auction auction) {
+        return new AuctionSearchResult(
+            auction.getId(),
+            auction.getUserId(),
+            auction.getDescription(),
+            auction.getMaxPrice(),
+            auction.getItemName(),
+            auction.getStatus(),
+            auction.getStartedAt(),
+            auction.getEndedAt(),
+            auction.getCancelledAt(),
+            auction.getCategoryId(),
+            auction.getCreatedAt()
+        );
+    }
+
+    public static AuctionSearchResult from(AuctionDocument auctionDoc) {
+        return new AuctionSearchResult(
+            auctionDoc.getId(),
+            auctionDoc.getUserId(),
+            auctionDoc.getDescription(),
+            auctionDoc.getMaxPrice(),
+            auctionDoc.getItemName(),
+            auctionDoc.getStatus(),
+            auctionDoc.getStartedAt(),
+            auctionDoc.getEndedAt(),
+            auctionDoc.getCancelledAt(),
+            auctionDoc.getCategoryId(),
+            auctionDoc.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/auction/domain/auction/search/repository/AuctionDocumentRepository.java
+++ b/src/main/java/com/example/auction/domain/auction/search/repository/AuctionDocumentRepository.java
@@ -4,4 +4,4 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 
 import com.example.auction.domain.auction.search.document.AuctionDocument;
 
-interface AuctionDocumentRepository extends ElasticsearchRepository<AuctionDocument, Long> {}
+public interface AuctionDocumentRepository extends ElasticsearchRepository<AuctionDocument, Long> {}

--- a/src/main/java/com/example/auction/domain/auction/search/repository/AuctionDocumentRepository.java
+++ b/src/main/java/com/example/auction/domain/auction/search/repository/AuctionDocumentRepository.java
@@ -1,0 +1,7 @@
+package com.example.auction.domain.auction.search.repository;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import com.example.auction.domain.auction.search.document.AuctionDocument;
+
+interface AuctionDocumentRepository extends ElasticsearchRepository<AuctionDocument, Long> {}

--- a/src/main/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchService.java
+++ b/src/main/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchService.java
@@ -7,6 +7,7 @@ import co.elastic.clients.elasticsearch._types.*;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHitSupport;
@@ -16,7 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import com.example.auction.domain.auction.dto.AuctionAdminListResponse;
 import com.example.auction.domain.auction.dto.AuctionSearchCondition;
+import com.example.auction.domain.auction.enums.AuctionStatus;
 import com.example.auction.domain.auction.search.document.AuctionDocument;
 import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
 import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
@@ -184,5 +187,79 @@ public class AuctionElasticsearchService {
             AuctionSearchCondition condition
     ) {
         return searchAuctionFromElasticsearchImpl(null, condition);
+    }
+
+    public Page<AuctionAdminListResponse> searchAuctionWithConditionsFromElasticsearch (
+            Pageable pageable, AuctionStatus auctionStatus, String keyword
+    ) {
+        List<Query> mustQueries = new ArrayList<>();
+
+        // 경매 상태 조건
+        if (auctionStatus != null) {
+            Query statusQuery = QueryBuilders.term()
+                .field("status")
+                .value(FieldValue.of(auctionStatus))
+                .build()
+                ._toQuery();
+
+            mustQueries.add(statusQuery);
+        }
+
+        // 이름 키워드 조건
+        if (keyword != null && !keyword.isBlank()) {
+            Query nameQuery = QueryBuilders.match()
+                .query(keyword)
+                .field("itemName")
+                .build()
+                ._toQuery();
+
+            mustQueries.add(nameQuery);
+        }
+
+        Query finalQuery;
+
+        if (mustQueries.isEmpty()) {
+            finalQuery = QueryBuilders.matchAll().build()._toQuery();
+        } else {
+            finalQuery = QueryBuilders.bool().must(mustQueries).build()._toQuery();
+        }
+
+        // TODO:
+        // 
+        // 현재 검색 순위 로직은 keyword가 있을 경우
+        // keyword랑 비슷한 제목의 목록은 점수가 높아 올라가고
+        // 점수가 똑같을 경우 생성된 날을 기준으로 정렬합니다.
+        //
+        // 문제는 한 10년된 경매도 검색어랑 제일 비슷하면 위로 올라간다는 점입니다.
+        //
+        // 보시다 시피 위와 똑같은 문제를 겪고 있지만 이 API는 관리자를 위한 API인 만큼
+        // 또 다른 조건이 필요할 수도 있을 듯 합니다.
+        List<SortOptions> sortOptions = new ArrayList<>();
+        sortOptions.add(SortOptions.of(s -> s.score(sc -> sc.order(SortOrder.Desc))));
+        sortOptions.add(SortOptions.of(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc))));
+
+        SearchHits<AuctionDocument> results = elasticsearch.search(
+                NativeQuery.builder()
+                .withQuery(finalQuery)
+                .withSort(sortOptions)
+                .withPageable(pageable)
+                .build(),
+                AuctionDocument.class);
+
+        return SearchHitSupport.searchPageFor(results, pageable)
+            .map(x -> {
+                AuctionDocument doc = x.getContent();
+                return new AuctionAdminListResponse(
+                        doc.getId(),
+                        doc.getUserId(),
+                        doc.getItemName(),
+                        doc.getCategoryId(),
+                        doc.getStatus(),
+                        doc.getCreatedAt(),
+                        doc.getStartedAt(),
+                        doc.getEndedAt(),
+                        doc.getCancelledAt()
+                );
+            });
     }
 }

--- a/src/main/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchService.java
+++ b/src/main/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchService.java
@@ -3,6 +3,7 @@ package com.example.auction.domain.auction.search.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import co.elastic.clients.elasticsearch._types.*;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +22,6 @@ import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
 import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
 import com.example.auction.domain.auction.util.AuctionUtil;
 
-import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.NumberRangeQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
@@ -144,6 +144,19 @@ public class AuctionElasticsearchService {
             finalQuery = QueryBuilders.bool().must(mustQueries).build()._toQuery();
         }
 
+        // TODO:
+        // 
+        // 현재 검색 순위 로직은 keyword가 있을 경우
+        // keyword랑 비슷한 제목의 목록은 점수가 높아 올라가고
+        // 점수가 똑같을 경우 생성된 날을 기준으로 정렬합니다.
+        //
+        // 문제는 한 10년된 경매도 검색어랑 제일 비슷하면 위로 올라간다는 점입니다.
+        //
+        // 오래됬을 경우 penaltiy를 주는 logic이 필요합니다.
+        List<SortOptions> sortOptions = new ArrayList<>();
+        sortOptions.add(SortOptions.of(s -> s.score(sc -> sc.order(SortOrder.Desc))));
+        sortOptions.add(SortOptions.of(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc))));
+
         PageRequest pageRequest = PageRequest.of(
                 condition.getPage(),
                 condition.getPageSize()
@@ -152,6 +165,7 @@ public class AuctionElasticsearchService {
         SearchHits<AuctionDocument> results = elasticsearch.search(
                 NativeQuery.builder()
                 .withQuery(finalQuery)
+                .withSort(sortOptions)
                 .withPageable(pageRequest)
                 .build(),
                 AuctionDocument.class);

--- a/src/main/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchService.java
+++ b/src/main/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchService.java
@@ -1,0 +1,174 @@
+package com.example.auction.domain.auction.search.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.example.auction.domain.auction.dto.AuctionSearchCondition;
+import com.example.auction.domain.auction.search.document.AuctionDocument;
+import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
+import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
+import com.example.auction.domain.auction.util.AuctionUtil;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.NumberRangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuctionElasticsearchService {
+    private final ElasticsearchOperations elasticsearch;
+
+    @Async("executorWithVT")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAuctionCreated(AuctionCreatedDocument event) {
+        int maxAttempts = 3;
+
+        int backoffBaseMilli = 500;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                AuctionDocument doc = AuctionDocument.from(event);
+                elasticsearch.save(doc);
+                return; // 성공하면 종료
+            } catch (Exception e) {
+                log.warn("[AuctionSearch] AuctionDocument 등록 실패 {}/{}회 - auctionId={}",
+                        attempt, maxAttempts, event.id(), e);
+                if (attempt == maxAttempts) {
+                    log.error("[AuctionSearch] AuctionDocument 등록 최종 실패 - auctionId={}",
+                            event.id(), e);
+                }else {
+                    try {
+                        Thread.sleep(backoffBaseMilli * (1L << attempt));
+                    } catch(InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+        }
+    }
+
+    private Page<AuctionSearchResult> searchAuctionFromElasticsearchImpl (
+            @Nullable Long userId,
+            AuctionSearchCondition condition
+    ) {
+        AuctionUtil.throwIfSearchConditionNotValid(condition);
+
+        List<Query> mustQueries = new ArrayList<>();
+
+        // 최대 가격 조건
+        if (condition.getMaxPriceMin() != null || condition.getMaxPriceMax() != null) {
+            NumberRangeQuery.Builder nrqBuilder = new NumberRangeQuery.Builder().field("maxPrice");
+
+            if (condition.getMaxPriceMin() != null) {
+                nrqBuilder.gte(condition.getMaxPriceMin().doubleValue());
+            }
+
+            if (condition.getMaxPriceMax() != null) {
+                nrqBuilder.lte(condition.getMaxPriceMax().doubleValue());
+            }
+
+            Query priceRange = QueryBuilders.range().number(nrqBuilder.build()).build()._toQuery();
+
+            mustQueries.add(priceRange);
+        }
+
+        // 경매 상태 조건
+        if (condition.getStatus() != null) {
+            List<FieldValue> statusFieldValues = condition.getStatus().stream()
+                .map(s -> FieldValue.of(s.name()))
+                .toList();
+
+            Query statusQuery = QueryBuilders.terms()
+                .field("status")
+                .terms(t -> t.value(statusFieldValues))
+                .build()
+                ._toQuery();
+
+            mustQueries.add(statusQuery);
+        }
+
+        // 카테고리 조건
+        if (condition.getCategoryId() != null) {
+            Query categoryQuery = QueryBuilders.term()
+                .field("categoryId")
+                .value(FieldValue.of(condition.getCategoryId()))
+                .build()
+                ._toQuery();
+
+            mustQueries.add(categoryQuery);
+        }
+
+        // 이름 키워드 조건
+        if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
+            Query nameQuery = QueryBuilders.match()
+                .query(condition.getKeyword())
+                .field("itemName")
+                .build()
+                ._toQuery();
+
+            mustQueries.add(nameQuery);
+        }
+
+        // 유저 ID 조건
+        if (userId != null) {
+            Query userIdQuery = QueryBuilders.term()
+                .field("userId")
+                .value(userId)
+                .build()
+                ._toQuery();
+
+            mustQueries.add(userIdQuery);
+        }
+
+        Query finalQuery;
+
+        if (mustQueries.isEmpty()) {
+            finalQuery = QueryBuilders.matchAll().build()._toQuery();
+        } else {
+            finalQuery = QueryBuilders.bool().must(mustQueries).build()._toQuery();
+        }
+
+        PageRequest pageRequest = PageRequest.of(
+                condition.getPage(),
+                condition.getPageSize()
+                );
+
+        SearchHits<AuctionDocument> results = elasticsearch.search(
+                NativeQuery.builder()
+                .withQuery(finalQuery)
+                .withPageable(pageRequest)
+                .build(),
+                AuctionDocument.class);
+
+        return SearchHitSupport.searchPageFor(results, pageRequest).map(x -> AuctionSearchResult.from(x.getContent()));
+    }
+
+    public Page<AuctionSearchResult> searchAuctionFromElasticsearch(
+            Long userId,
+            AuctionSearchCondition condition
+    ) {
+        return searchAuctionFromElasticsearchImpl(userId, condition);
+    }
+
+    public Page<AuctionSearchResult> searchAuctionFromElasticsearch(
+            AuctionSearchCondition condition
+    ) {
+        return searchAuctionFromElasticsearchImpl(null, condition);
+    }
+}

--- a/src/main/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchService.java
+++ b/src/main/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchService.java
@@ -198,7 +198,7 @@ public class AuctionElasticsearchService {
         if (auctionStatus != null) {
             Query statusQuery = QueryBuilders.term()
                 .field("status")
-                .value(FieldValue.of(auctionStatus))
+                .value(FieldValue.of(auctionStatus.name()))
                 .build()
                 ._toQuery();
 

--- a/src/main/java/com/example/auction/domain/auction/search/service/AuctionSearchService.java
+++ b/src/main/java/com/example/auction/domain/auction/search/service/AuctionSearchService.java
@@ -4,10 +4,13 @@ import com.example.auction.domain.auction.repository.AuctionRepository;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.example.auction.domain.auction.dto.AuctionAdminListResponse;
 import com.example.auction.domain.auction.dto.AuctionSearchCondition;
+import com.example.auction.domain.auction.enums.AuctionStatus;
 import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
 import com.example.auction.domain.auction.util.AuctionUtil;
 
@@ -93,5 +96,22 @@ public class AuctionSearchService {
         }
 
         return auctionElasticsearchService.searchAuctionFromElasticsearch(userId, condition);
+    }
+
+    public Page<AuctionAdminListResponse> searchAuctionWithConditions(
+            Pageable pageable, AuctionStatus auctionStatus, String keyword
+    ) {
+        if (keyword == null || keyword.isBlank()) {
+            try {
+                return auctionRepository.findAuctionWithConditions(pageable, auctionStatus, keyword);
+            } catch (Exception e) {
+                log.error("[AuctionSearch] DB 키워드 없는 검색 실패, elasticsearch로 fallback - pageable={}, auctionStatus={}, keyword={}",
+                        pageable, auctionStatus, keyword, e);
+
+                return auctionElasticsearchService.searchAuctionWithConditionsFromElasticsearch(pageable, auctionStatus, keyword);
+            }
+        }
+
+        return auctionElasticsearchService.searchAuctionWithConditionsFromElasticsearch(pageable, auctionStatus, keyword);
     }
 }

--- a/src/main/java/com/example/auction/domain/auction/search/service/AuctionSearchService.java
+++ b/src/main/java/com/example/auction/domain/auction/search/service/AuctionSearchService.java
@@ -1,160 +1,68 @@
 package com.example.auction.domain.auction.search.service;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.example.auction.domain.auction.repository.AuctionRepository;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.elasticsearch.client.elc.NativeQuery;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.SearchHitSupport;
-import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.example.auction.domain.auction.dto.AuctionSearchCondition;
-import com.example.auction.domain.auction.search.document.AuctionDocument;
-import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
 import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
 import com.example.auction.domain.auction.util.AuctionUtil;
 
-import co.elastic.clients.elasticsearch._types.FieldValue;
-import co.elastic.clients.elasticsearch._types.query_dsl.NumberRangeQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class AuctionSearchService {
-    private final ElasticsearchOperations elasticsearch;
-
-    private final PlatformTransactionManager txManager;
+    private final TransactionTemplate txTemplate;
     private final AuctionRepository auctionRepository;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleAuctionCreated(AuctionCreatedDocument event) {
-        int maxAttempts = 3;
-        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
-            try {
-                AuctionDocument doc = AuctionDocument.from(event);
-                elasticsearch.save(doc);
-                return; // 성공하면 종료
-            } catch (Exception e) {
-                log.warn("[AuctionSearch] AuctionDocument 등록 실패 {}/{}회 - auctionId={}",
-                        attempt, maxAttempts, event.id(), e);
-                if (attempt == maxAttempts) {
-                    log.error("[AuctionSearch] AuctionDocument 등록 최종 실패 - auctionId={}",
-                            event.id(), e);
-                }
+    private final AuctionElasticsearchService auctionElasticsearchService;
 
-                // TODO: exponential backoff 적용
-            }
-        }
+    public AuctionSearchService(
+            PlatformTransactionManager txManager,
+            AuctionRepository auctionRepository,
+            AuctionElasticsearchService auctionElasticsearchService
+    ) {
+        this.txTemplate = new TransactionTemplate(txManager);
+        txTemplate.setReadOnly(true);
+
+        this.auctionRepository = auctionRepository;
+        this.auctionElasticsearchService = auctionElasticsearchService;
     }
 
-    public Page<AuctionSearchResult> searchAuctionFromElasticsearch (
+    private Page<AuctionSearchResult> searchAuctionFromDbImpl(
+            @Nullable Long userId,
             AuctionSearchCondition condition
     ) {
         AuctionUtil.throwIfSearchConditionNotValid(condition);
 
-        List<Query> mustQueries = new ArrayList<>();
-
-        if (condition.getMaxPriceMin() != null || condition.getMaxPriceMax() != null) {
-            NumberRangeQuery.Builder nrqBuilder = new NumberRangeQuery.Builder().field("maxPrice");
-
-            if (condition.getMaxPriceMin() != null) {
-                nrqBuilder.gte(condition.getMaxPriceMin().doubleValue());
-            }
-
-            if (condition.getMaxPriceMax() != null) {
-                nrqBuilder.lte(condition.getMaxPriceMax().doubleValue());
-            }
-
-            Query priceRange = QueryBuilders.range().number(nrqBuilder.build()).build()._toQuery();
-
-            mustQueries.add(priceRange);
-        }
-
-        if (condition.getStatus() != null) {
-            List<FieldValue> statusFieldValues = condition.getStatus().stream()
-                .map(s -> FieldValue.of(s.name()))
-                .toList();
-
-            Query statusQuery = QueryBuilders.terms()
-                .field("status")
-                .terms(t -> t.value(statusFieldValues))
-                .build()
-                ._toQuery();
-
-            mustQueries.add(statusQuery);
-        }
-
-        if (condition.getCategoryId() != null) {
-            Query categoryQuery = QueryBuilders.term()
-                .field("categoryId")
-                .value(FieldValue.of(condition.getCategoryId()))
-                .build()
-                ._toQuery();
-
-            mustQueries.add(categoryQuery);
-        }
-
-        if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
-            Query nameQuery = QueryBuilders.match()
-                .query(condition.getKeyword())
-                .field("itemName")
-                .build()
-                ._toQuery();
-
-            mustQueries.add(nameQuery);
-        }
-
-        Query finalQuery;
-
-        if (mustQueries.isEmpty()) {
-            finalQuery = QueryBuilders.matchAll().build()._toQuery();
+        if (userId == null) {
+            return txTemplate.execute(status -> auctionRepository.findByCondition(condition).map(AuctionSearchResult::from));
         } else {
-            finalQuery = QueryBuilders.bool().must(mustQueries).build()._toQuery();
+            return txTemplate.execute(status -> auctionRepository.findByUserIdAndCondition(userId, condition).map(AuctionSearchResult::from));
         }
-
-        PageRequest pageRequest = PageRequest.of(
-                condition.getPage(),
-                condition.getPageSize()
-                );
-
-        SearchHits<AuctionDocument> results = elasticsearch.search(
-                NativeQuery.builder()
-                .withQuery(finalQuery)
-                .withPageable(pageRequest)
-                .build(),
-                AuctionDocument.class);
-
-        return SearchHitSupport.searchPageFor(results, pageRequest).map(x -> AuctionSearchResult.from(x.getContent()));
     }
 
-    public Page<AuctionSearchResult> searchAuctionFromDb (
+    public Page<AuctionSearchResult> searchAuctionFromDb(
+            Long userId,
             AuctionSearchCondition condition
     ) {
-        AuctionUtil.throwIfSearchConditionNotValid(condition);
-
-        TransactionTemplate tx = new TransactionTemplate(txManager);
-        tx.setReadOnly(true);
-
-        return tx.execute(status-> auctionRepository.findByCondition(condition).map(AuctionSearchResult::from));
+        return searchAuctionFromDbImpl(userId, condition);
     }
 
-    public Page<AuctionSearchResult> searchAuction (
+    public Page<AuctionSearchResult> searchAuctionFromDb(
             AuctionSearchCondition condition
     ) {
-        AuctionUtil.throwIfSearchConditionNotValid(condition);
+        return searchAuctionFromDbImpl(null, condition);
+    }
 
+    public Page<AuctionSearchResult> searchAuction(
+            AuctionSearchCondition condition
+    ) {
         if (condition.getKeyword() == null || condition.getKeyword().isBlank()) {
             try {
                 return searchAuctionFromDb(condition);
@@ -162,10 +70,28 @@ public class AuctionSearchService {
                 log.error("[AuctionSearch] DB 키워드 없는 검색 실패, elasticsearch로 fallback - {}",
                         condition.toLogString(), e);
 
-                return searchAuctionFromElasticsearch(condition);
+                return auctionElasticsearchService.searchAuctionFromElasticsearch(condition);
             }
         }
 
-        return searchAuctionFromElasticsearch(condition);
+        return auctionElasticsearchService.searchAuctionFromElasticsearch(condition);
+    }
+
+    public Page<AuctionSearchResult> searchAuction(
+            Long userId,
+            AuctionSearchCondition condition
+    ) {
+        if (condition.getKeyword() == null || condition.getKeyword().isBlank()) {
+            try {
+                return searchAuctionFromDb(userId, condition);
+            } catch (Exception e) {
+                log.error("[AuctionSearch] DB 키워드 없는 검색 실패, elasticsearch로 fallback - userId={}, {}",
+                        userId, condition.toLogString(), e);
+
+                return auctionElasticsearchService.searchAuctionFromElasticsearch(userId, condition);
+            }
+        }
+
+        return auctionElasticsearchService.searchAuctionFromElasticsearch(userId, condition);
     }
 }

--- a/src/main/java/com/example/auction/domain/auction/search/service/AuctionSearchService.java
+++ b/src/main/java/com/example/auction/domain/auction/search/service/AuctionSearchService.java
@@ -1,0 +1,171 @@
+package com.example.auction.domain.auction.search.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.example.auction.domain.auction.repository.AuctionRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.example.auction.domain.auction.dto.AuctionSearchCondition;
+import com.example.auction.domain.auction.search.document.AuctionDocument;
+import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
+import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
+import com.example.auction.domain.auction.util.AuctionUtil;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.NumberRangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuctionSearchService {
+    private final ElasticsearchOperations elasticsearch;
+
+    private final PlatformTransactionManager txManager;
+    private final AuctionRepository auctionRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAuctionCreated(AuctionCreatedDocument event) {
+        int maxAttempts = 3;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                AuctionDocument doc = AuctionDocument.from(event);
+                elasticsearch.save(doc);
+                return; // 성공하면 종료
+            } catch (Exception e) {
+                log.warn("[AuctionSearch] AuctionDocument 등록 실패 {}/{}회 - auctionId={}",
+                        attempt, maxAttempts, event.id(), e);
+                if (attempt == maxAttempts) {
+                    log.error("[AuctionSearch] AuctionDocument 등록 최종 실패 - auctionId={}",
+                            event.id(), e);
+                }
+
+                // TODO: exponential backoff 적용
+            }
+        }
+    }
+
+    public Page<AuctionSearchResult> searchAuctionFromElasticsearch (
+            AuctionSearchCondition condition
+    ) {
+        AuctionUtil.throwIfSearchConditionNotValid(condition);
+
+        List<Query> mustQueries = new ArrayList<>();
+
+        if (condition.getMaxPriceMin() != null || condition.getMaxPriceMax() != null) {
+            NumberRangeQuery.Builder nrqBuilder = new NumberRangeQuery.Builder().field("maxPrice");
+
+            if (condition.getMaxPriceMin() != null) {
+                nrqBuilder.gte(condition.getMaxPriceMin().doubleValue());
+            }
+
+            if (condition.getMaxPriceMax() != null) {
+                nrqBuilder.lte(condition.getMaxPriceMax().doubleValue());
+            }
+
+            Query priceRange = QueryBuilders.range().number(nrqBuilder.build()).build()._toQuery();
+
+            mustQueries.add(priceRange);
+        }
+
+        if (condition.getStatus() != null) {
+            List<FieldValue> statusFieldValues = condition.getStatus().stream()
+                .map(s -> FieldValue.of(s.name()))
+                .toList();
+
+            Query statusQuery = QueryBuilders.terms()
+                .field("status")
+                .terms(t -> t.value(statusFieldValues))
+                .build()
+                ._toQuery();
+
+            mustQueries.add(statusQuery);
+        }
+
+        if (condition.getCategoryId() != null) {
+            Query categoryQuery = QueryBuilders.term()
+                .field("categoryId")
+                .value(FieldValue.of(condition.getCategoryId()))
+                .build()
+                ._toQuery();
+
+            mustQueries.add(categoryQuery);
+        }
+
+        if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
+            Query nameQuery = QueryBuilders.match()
+                .query(condition.getKeyword())
+                .field("itemName")
+                .build()
+                ._toQuery();
+
+            mustQueries.add(nameQuery);
+        }
+
+        Query finalQuery;
+
+        if (mustQueries.isEmpty()) {
+            finalQuery = QueryBuilders.matchAll().build()._toQuery();
+        } else {
+            finalQuery = QueryBuilders.bool().must(mustQueries).build()._toQuery();
+        }
+
+        PageRequest pageRequest = PageRequest.of(
+                condition.getPage(),
+                condition.getPageSize()
+                );
+
+        SearchHits<AuctionDocument> results = elasticsearch.search(
+                NativeQuery.builder()
+                .withQuery(finalQuery)
+                .withPageable(pageRequest)
+                .build(),
+                AuctionDocument.class);
+
+        return SearchHitSupport.searchPageFor(results, pageRequest).map(x -> AuctionSearchResult.from(x.getContent()));
+    }
+
+    public Page<AuctionSearchResult> searchAuctionFromDb (
+            AuctionSearchCondition condition
+    ) {
+        AuctionUtil.throwIfSearchConditionNotValid(condition);
+
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+        tx.setReadOnly(true);
+
+        return tx.execute(status-> auctionRepository.findByCondition(condition).map(AuctionSearchResult::from));
+    }
+
+    public Page<AuctionSearchResult> searchAuction (
+            AuctionSearchCondition condition
+    ) {
+        AuctionUtil.throwIfSearchConditionNotValid(condition);
+
+        if (condition.getKeyword() == null || condition.getKeyword().isBlank()) {
+            try {
+                return searchAuctionFromDb(condition);
+            } catch (Exception e) {
+                log.error("[AuctionSearch] DB 키워드 없는 검색 실패, elasticsearch로 fallback - {}",
+                        condition.toLogString(), e);
+
+                return searchAuctionFromElasticsearch(condition);
+            }
+        }
+
+        return searchAuctionFromElasticsearch(condition);
+    }
+}

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionAdminService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionAdminService.java
@@ -8,6 +8,8 @@ import com.example.auction.domain.auction.entity.Auction;
 import com.example.auction.domain.auction.enums.AuctionStatus;
 import com.example.auction.domain.auction.exception.AuctionErrorEnum;
 import com.example.auction.domain.auction.repository.AuctionRepository;
+import com.example.auction.domain.auction.search.service.AuctionSearchService;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
@@ -21,10 +23,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuctionAdminService {
 
     private final AuctionRepository auctionRepository;
+    private final AuctionSearchService auctionSearchService;
 
     @Transactional(readOnly = true)
     public PageResponse<AuctionAdminListResponse> getAuctionList(AuctionAdminSearchCondition condition) {
-        Page<AuctionAdminListResponse> auctionList = auctionRepository.findAuctionWithConditions(
+        Page<AuctionAdminListResponse> auctionList = auctionSearchService.searchAuctionWithConditions(
                 PageRequest.of(condition.getPage(), condition.getSize()),
                 condition.getAuctionStatus(),
                 condition.getKeyword()

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
@@ -3,7 +3,6 @@ package com.example.auction.domain.auction.service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-import org.jspecify.annotations.NonNull;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
@@ -87,7 +86,7 @@ public class AuctionService {
 
         Page<AuctionSearchResult> searchResults = auctionSearchService.searchAuction(condition);
 
-        Page<@NonNull GetManyAuctionsResponse> dtos = searchResults.map(GetManyAuctionsResponse::from);
+        Page<GetManyAuctionsResponse> dtos = searchResults.map(GetManyAuctionsResponse::from);
         
         return PageResponse.create(dtos);
     }
@@ -99,11 +98,11 @@ public class AuctionService {
     ) {
         AuctionUtil.throwIfSearchConditionNotValid(condition);
 
-        Page<@NonNull Auction> auctions = auctionRepository.findByUserIdAndCondition(
+        Page<AuctionSearchResult> searchResults = auctionSearchService.searchAuction(
                 userDetails.getUserId(), condition
         );
 
-        Page<@NonNull GetManyAuctionsResponse> auctionsDto = auctions.map(GetManyAuctionsResponse::from);
+        Page<GetManyAuctionsResponse> auctionsDto = searchResults.map(GetManyAuctionsResponse::from);
         
         return PageResponse.create(auctionsDto);
     }

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
@@ -3,10 +3,6 @@ package com.example.auction.domain.auction.service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-import com.example.auction.domain.auction.eventBridge.AuctionCreatedEventBridge;
-import com.example.auction.domain.auction.eventBridge.AuctionEventBridgeService;
-import com.example.auction.domain.category.exception.CategoryErrorEnum;
-import com.example.auction.domain.category.repository.CategoryRepository;
 import org.jspecify.annotations.NonNull;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
@@ -26,11 +22,18 @@ import com.example.auction.domain.auction.dto.GetAuctionResponse;
 import com.example.auction.domain.auction.dto.GetManyAuctionsResponse;
 import com.example.auction.domain.auction.entity.Auction;
 import com.example.auction.domain.auction.enums.AuctionStatus;
+import com.example.auction.domain.auction.eventBridge.AuctionCreatedEventBridge;
+import com.example.auction.domain.auction.eventBridge.AuctionEventBridgeService;
 import com.example.auction.domain.auction.exception.AuctionErrorEnum;
 import com.example.auction.domain.auction.repository.AuctionRepository;
+import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
+import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
+import com.example.auction.domain.auction.search.service.AuctionSearchService;
 import com.example.auction.domain.auction.util.AuctionUtil;
-import com.example.auction.domain.user.repository.UserRepository;
+import com.example.auction.domain.category.exception.CategoryErrorEnum;
+import com.example.auction.domain.category.repository.CategoryRepository;
 import com.example.auction.domain.user.exception.UserErrorEnum;
+import com.example.auction.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,6 +45,7 @@ public class AuctionService {
     private final CategoryRepository categoryRepository;
     private final AuctionEventBridgeService auctionEventBridgeService;
     private final ApplicationEventPublisher eventPublisher;
+    private final AuctionSearchService auctionSearchService;
 
     @Transactional(readOnly = true)
     @Cacheable(
@@ -56,7 +60,6 @@ public class AuctionService {
         return GetAuctionResponse.from(auction);
     }
 
-    @Transactional(readOnly = true)
     @Cacheable(
         cacheNames = {"getManyAuctionsPublic"},
         key = "@auctionCacheService.getManyAuctionsPublicCacheKey(#condition)",
@@ -82,13 +85,11 @@ public class AuctionService {
 
         AuctionUtil.throwIfSearchConditionNotValid(condition);
 
-        Page<@NonNull Auction> auctions = auctionRepository.findByCondition(
-                condition
-        );
+        Page<AuctionSearchResult> searchResults = auctionSearchService.searchAuction(condition);
 
-        Page<@NonNull GetManyAuctionsResponse> auctionsDto = auctions.map(GetManyAuctionsResponse::from);
+        Page<@NonNull GetManyAuctionsResponse> dtos = searchResults.map(GetManyAuctionsResponse::from);
         
-        return PageResponse.create(auctionsDto);
+        return PageResponse.create(dtos);
     }
 
     @Transactional(readOnly = true)
@@ -143,9 +144,13 @@ public class AuctionService {
         auction = auctionRepository.saveAndFlush(auction);
 
         // 이벤트퍼블리셔를 활용하여 트랜잭션 밖으로 빼냄
+
         // 트랜잭션 커밋 이후 EventBridge 등록 (고아 스케줄 방지)
         // 이 매서드의 트랜잭션 커밋이 끝나면 event가 발행되고, AuctionEventBridgeService의 handleAuctionCreated 가 실행됨
         eventPublisher.publishEvent(new AuctionCreatedEventBridge(auction.getId(), auction.getStartedAt(), auction.getEndedAt()));
+
+        // 이 매서드의 트랜잭션 커밋이 끝나면 event가 발행되고, AuctionSearchService의 handleAuctionCreated 가 실행됨
+        eventPublisher.publishEvent(AuctionCreatedDocument.from(auction));
 
         return GetAuctionResponse.from(auction);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
 
   # Elasticsearch 관련
   elasticsearch:
-    username: elastic
+    username: ${ELASTICSEARCH_USERNAME}
     password: ${ELASTICSEARCH_PASSWORD}
     uris: ${ELASTICSEARCH_URIS}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,8 @@ spring:
 
   # Elasticsearch 관련
   elasticsearch:
+    username: elastic
+    password: ${ELASTICSEARCH_PASSWORD}
     uris: ${ELASTICSEARCH_URIS}
 
   cloud:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,10 @@ spring:
         options:
           model: text-embedding-3-small    # 텍스트 → 벡터 변환 전용 임베딩 모델 (RAG용)
 
+  # Elasticsearch 관련
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URIS}
+
   cloud:
     # AWS 관련
     aws:

--- a/src/test/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchServiceTest.java
+++ b/src/test/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchServiceTest.java
@@ -22,7 +22,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.example.auction.domain.auction.dto.AuctionAdminListResponse;
 import com.example.auction.domain.auction.dto.AuctionSearchCondition;
@@ -56,7 +55,6 @@ class AuctionElasticsearchServiceTest extends BaseIntegrationTest {
      * AuctionSearchCondition이 기본값일 때 모든 데이터를 가지고 오는지 확인합니다.
      */
     @Test
-    @Transactional
     void findSimple() {
         AuctionCreatedDocument event = new AuctionCreatedDocument(
             1L,
@@ -90,7 +88,6 @@ class AuctionElasticsearchServiceTest extends BaseIntegrationTest {
      */
     @ParameterizedTest(name = "{0}")
     @MethodSource("getFindMinMaxPriceRangeSources")
-    @Transactional
     void findMinMaxPriceRange(String name, AuctionSearchCondition condition, int expectingAuction) {
         long[] idCounter = {1};
 
@@ -155,7 +152,6 @@ class AuctionElasticsearchServiceTest extends BaseIntegrationTest {
      */
     @ParameterizedTest(name = "{0}")
     @MethodSource("getFindByStatusSources")
-    @Transactional
     void findByStatus(String name, AuctionSearchCondition condition, AuctionStatus[] statuses) {
         long[] idCounter = {1};
 

--- a/src/test/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchServiceTest.java
+++ b/src/test/java/com/example/auction/domain/auction/search/service/AuctionElasticsearchServiceTest.java
@@ -1,0 +1,420 @@
+package com.example.auction.domain.auction.search.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.example.auction.domain.auction.search.document.AuctionDocument;
+import com.example.auction.domain.auction.search.dto.AuctionCreatedDocument;
+import com.example.auction.domain.auction.search.dto.AuctionSearchResult;
+import com.example.auction.domain.auction.search.repository.AuctionDocumentRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.auction.domain.auction.dto.AuctionAdminListResponse;
+import com.example.auction.domain.auction.dto.AuctionSearchCondition;
+import com.example.auction.domain.auction.enums.AuctionStatus;
+import com.example.auction.testutils.BaseIntegrationTest;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AuctionElasticsearchServiceTest extends BaseIntegrationTest {
+    // 가짜 유저 ID
+    public static final Long FAKE_USER_ID = 1L;
+
+    // 가짜 카테고리 ID
+    public static final Long FAKE_CATEGORY_ID = 1L;
+
+    @Autowired
+    AuctionDocumentRepository auctionDocumentRepository;
+
+    @Autowired
+    AuctionElasticsearchService auctionElasticsearchService;
+
+    @BeforeEach
+    @AfterEach
+    void clearElasticsearchIndex() {
+        auctionDocumentRepository.deleteAll();
+    }
+
+    /**
+     * AuctionSearchCondition이 기본값일 때 모든 데이터를 가지고 오는지 확인합니다.
+     */
+    @Test
+    @Transactional
+    void findSimple() {
+        AuctionCreatedDocument event = new AuctionCreatedDocument(
+            1L,
+            FAKE_USER_ID,
+            "test auction item name",
+            BigDecimal.valueOf(1000),
+            "test auction",
+            AuctionStatus.READY,
+            LocalDateTime.now().plusDays(1),
+            LocalDateTime.now().plusDays(2),
+            null,
+            FAKE_CATEGORY_ID,
+            LocalDateTime.now()
+        );
+
+        AuctionDocument auctionDocument = AuctionDocument.from(event);
+
+        AuctionSearchCondition condition = new AuctionSearchCondition();
+
+        auctionDocumentRepository.save(auctionDocument);
+
+        List<Long> resultIds = auctionElasticsearchService.searchAuctionFromElasticsearch(
+            condition
+        ).stream().map(AuctionSearchResult::id).toList();
+
+        assertThat(resultIds).contains(1L);
+    }
+
+    /**
+     * AuctionSearchCondition의 maxPriceMin과 maxPriceMax가 잘 작동하는 확인합니다.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getFindMinMaxPriceRangeSources")
+    @Transactional
+    void findMinMaxPriceRange(String name, AuctionSearchCondition condition, int expectingAuction) {
+        long[] idCounter = {1};
+
+        Function<BigDecimal, AuctionDocument> createAuction = (
+            maxPrice
+        ) -> {
+            AuctionCreatedDocument event = new AuctionCreatedDocument(
+                idCounter[0],
+                FAKE_USER_ID,
+                "test auction item name",
+                maxPrice,
+                "test auction",
+                AuctionStatus.READY,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+            );
+
+            idCounter[0]++;
+
+            return auctionDocumentRepository.save(AuctionDocument.from(event));
+        };
+
+        // GIVEN
+        AuctionDocument[] auctions = new AuctionDocument[] {
+                createAuction.apply(BigDecimal.valueOf(1000)),
+                createAuction.apply(BigDecimal.valueOf(2000)),
+                createAuction.apply(BigDecimal.valueOf(3000))
+        };
+
+        // WHEN
+        List<Long> foundAuctions = auctionElasticsearchService.searchAuctionFromElasticsearch(
+                condition
+        ).stream().map(AuctionSearchResult::id).toList();
+
+        // THEN
+        assertThat(foundAuctions).containsExactly(auctions[expectingAuction].getId());
+    }
+
+    private static Stream<Arguments> getFindMinMaxPriceRangeSources() {
+        AuctionSearchCondition cond1 = new AuctionSearchCondition();
+        cond1.setMaxPriceMin(BigDecimal.valueOf(2500));
+
+        AuctionSearchCondition cond2 = new AuctionSearchCondition();
+        cond2.setMaxPriceMax(BigDecimal.valueOf(1500));
+
+        AuctionSearchCondition cond3 = new AuctionSearchCondition();
+        cond3.setMaxPriceMin(BigDecimal.valueOf(1500));
+        cond3.setMaxPriceMax(BigDecimal.valueOf(2500));
+
+        return Stream.of(
+                Arguments.of("최소 가격 이상만 조회 가능", cond1, 2),
+                Arguments.of("최대 가격 이하만 조회 가능", cond2, 0),
+                Arguments.of("최소와 최대 가격 사이만 조회 가능", cond3, 1)
+        );
+    }
+
+    /**
+     * 경매의 상태로 필터링이 잘되는지 확인합니다
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getFindByStatusSources")
+    @Transactional
+    void findByStatus(String name, AuctionSearchCondition condition, AuctionStatus[] statuses) {
+        long[] idCounter = {1};
+
+        Function<AuctionStatus, AuctionDocument> createAuction = (
+                status
+        ) -> {
+            AuctionCreatedDocument event = new AuctionCreatedDocument(
+                    idCounter[0],
+                    FAKE_USER_ID,
+                    "test auction item name",
+                    BigDecimal.valueOf(1000),
+                    "test auction",
+                    status,
+                    LocalDateTime.now().plusDays(1),
+                    LocalDateTime.now().plusDays(2),
+                    null,
+                    FAKE_CATEGORY_ID,
+                    LocalDateTime.now()
+            );
+
+            idCounter[0]++;
+
+            return auctionDocumentRepository.save(AuctionDocument.from(event));
+        };
+
+        // GIVEN
+        createAuction.apply(AuctionStatus.READY);
+        createAuction.apply(AuctionStatus.ACTIVE);
+        createAuction.apply(AuctionStatus.DONE);
+        createAuction.apply(AuctionStatus.NO_BID);
+        createAuction.apply(AuctionStatus.CANCELLED);
+
+        // WHEN
+        List<AuctionStatus> foundAuctionStatuses = auctionElasticsearchService.searchAuctionFromElasticsearch(
+                condition
+        ).stream()
+            .map(AuctionSearchResult::status)
+            .distinct()
+            .toList();
+
+        // THEN
+        assertThat(foundAuctionStatuses).containsExactlyInAnyOrder(statuses);
+    }
+
+    private static Stream<Arguments> getFindByStatusSources() {
+        AuctionSearchCondition cond1 = new AuctionSearchCondition();
+        cond1.setDefaultStatusesIfEmpty(AuctionStatus.NO_BID);
+
+        AuctionSearchCondition cond2 = new AuctionSearchCondition();
+        cond2.setDefaultStatusesIfEmpty(AuctionStatus.ACTIVE, AuctionStatus.CANCELLED);
+
+        return Stream.of(
+                Arguments.of("경매 단일 조건 검색", cond1, new AuctionStatus[]{AuctionStatus.NO_BID}),
+                Arguments.of("경매 다수 조건 검색", cond2, new AuctionStatus[]{AuctionStatus.ACTIVE, AuctionStatus.CANCELLED})
+        );
+    }
+
+    // ========================
+    // 관리자 경매 목록 조회
+    // ========================
+
+    @Test
+    @DisplayName("관리자 경매 목록 조회 - 필터 없음 전체 조회")
+    void findAuctionWithConditions_noFilter() {
+        Long idCounter = 1L;
+
+        AuctionCreatedDocument normal = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(1000),
+                "노트북",
+                AuctionStatus.READY,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(normal));
+
+        AuctionCreatedDocument active = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(2000),
+                "키보드",
+                AuctionStatus.ACTIVE,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(active));
+
+        Page<AuctionAdminListResponse> result = auctionElasticsearchService.searchAuctionWithConditionsFromElasticsearch(
+                PageRequest.of(0, 10), null, null
+        );
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("관리자 경매 목록 조회 - 상태 필터링")
+    void findAuctionWithConditions_statusFilter() {
+        Long idCounter = 1L;
+
+        AuctionCreatedDocument normal = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(1000),
+                "노트북",
+                AuctionStatus.READY,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(normal));
+
+        AuctionCreatedDocument active = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(2000),
+                "키보드",
+                AuctionStatus.ACTIVE,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(active));
+
+        Page<AuctionAdminListResponse> result = auctionElasticsearchService.searchAuctionWithConditionsFromElasticsearch(
+                PageRequest.of(0, 10), AuctionStatus.ACTIVE, null
+        );
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).itemName()).isEqualTo("키보드");
+        assertThat(result.getContent().get(0).status()).isEqualTo(AuctionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("관리자 경매 목록 조회 - 키워드 필터링")
+    void findAuctionWithConditions_keywordFilter() {
+        Long idCounter = 1L;
+
+        AuctionCreatedDocument normal = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(1000),
+                "노트북",
+                AuctionStatus.READY,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(normal));
+
+        AuctionCreatedDocument active = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(2000),
+                "키보드",
+                AuctionStatus.ACTIVE,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(active));
+
+        Page<AuctionAdminListResponse> result = auctionElasticsearchService.searchAuctionWithConditionsFromElasticsearch(
+                PageRequest.of(0, 10), null, "노트"
+        );
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).itemName()).isEqualTo("노트북");
+    }
+
+    @Test
+    @DisplayName("관리자 경매 목록 조회 - 상태 + 키워드 동시 필터링")
+    void findAuctionWithConditions_statusAndKeyword() {
+        Long idCounter = 1L;
+
+        AuctionCreatedDocument normal = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(1000),
+                "노트북",
+                AuctionStatus.READY,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(normal));
+
+        AuctionCreatedDocument active = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(2000),
+                "노트북 거치대",
+                AuctionStatus.ACTIVE,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(active));
+
+        Page<AuctionAdminListResponse> result = auctionElasticsearchService.searchAuctionWithConditionsFromElasticsearch(
+                PageRequest.of(0, 10), AuctionStatus.ACTIVE, "노트북"
+        );
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).itemName()).isEqualTo("노트북 거치대");
+    }
+
+    @Test
+    @DisplayName("관리자 경매 목록 조회 - 조건에 맞는 결과 없음")
+    void findAuctionWithConditions_noMatch() {
+        Long idCounter = 1L;
+
+        AuctionCreatedDocument normal = new AuctionCreatedDocument(
+                idCounter++,
+                FAKE_USER_ID,
+                null,
+                BigDecimal.valueOf(1000),
+                "노트북",
+                AuctionStatus.READY,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                null,
+                FAKE_CATEGORY_ID,
+                LocalDateTime.now()
+        );
+        auctionDocumentRepository.save(AuctionDocument.from(normal));
+
+        Page<AuctionAdminListResponse> result = auctionElasticsearchService.searchAuctionWithConditionsFromElasticsearch(
+                PageRequest.of(0, 10), AuctionStatus.ACTIVE, null
+        );
+
+        assertThat(result.getTotalElements()).isEqualTo(0);
+        assertThat(result.getContent()).isEmpty();
+    }
+}

--- a/src/test/java/com/example/auction/domain/auction/service/AuctionAdminServiceTest.java
+++ b/src/test/java/com/example/auction/domain/auction/service/AuctionAdminServiceTest.java
@@ -8,6 +8,8 @@ import com.example.auction.domain.auction.entity.Auction;
 import com.example.auction.domain.auction.enums.AuctionStatus;
 import com.example.auction.domain.auction.exception.AuctionErrorEnum;
 import com.example.auction.domain.auction.repository.AuctionRepository;
+import com.example.auction.domain.auction.search.service.AuctionSearchService;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +41,9 @@ class AuctionAdminServiceTest {
     @Mock
     private AuctionRepository auctionRepository;
 
+    @Mock
+    private AuctionSearchService auctionSearchService;
+
 
     // ========================
     // 경매 목록 조회
@@ -58,7 +63,7 @@ class AuctionAdminServiceTest {
         );
         Page<AuctionAdminListResponse> page = new PageImpl<>(auctionList, PageRequest.of(0,20), 3);
 
-        given(auctionRepository.findAuctionWithConditions(any(Pageable.class), any(), any())).willReturn(page);
+        given(auctionSearchService.searchAuctionWithConditions(any(Pageable.class), any(), any())).willReturn(page);
 
         // when
         PageResponse<AuctionAdminListResponse> response = auctionAdminService.getAuctionList(condition);
@@ -79,7 +84,7 @@ class AuctionAdminServiceTest {
         AuctionAdminSearchCondition condition = new AuctionAdminSearchCondition();
         Page<AuctionAdminListResponse> page = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
 
-        given(auctionRepository.findAuctionWithConditions(any(Pageable.class), any(), any())).willReturn(page);
+        given(auctionSearchService.searchAuctionWithConditions(any(Pageable.class), any(), any())).willReturn(page);
 
         // when
         PageResponse<AuctionAdminListResponse> response = auctionAdminService.getAuctionList(condition);

--- a/src/test/java/com/example/auction/testutils/BaseIntegrationTest.java
+++ b/src/test/java/com/example/auction/testutils/BaseIntegrationTest.java
@@ -89,6 +89,6 @@ fi &&
 
         registry.add("spring.elasticsearch.username", ()-> "elastic" );
         registry.add("spring.elasticsearch.password", ()-> "1234" );
-        registry.add("spring.elasticsearch.uris", elasticsearch::getHttpHostAddress);
+        registry.add("spring.elasticsearch.uris", () -> "http://" + elasticsearch.getHttpHostAddress());
     }
 }

--- a/src/test/java/com/example/auction/testutils/BaseIntegrationTest.java
+++ b/src/test/java/com/example/auction/testutils/BaseIntegrationTest.java
@@ -11,7 +11,7 @@ import org.testcontainers.utility.MountableFile;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 /**
- * pgvector와 Redis를 Testcontainers로 실행하는 통합 테스트 기반 클래스입니다.
+ * pgvector와 Redis, elasticsearch를 Testcontainers로 실행하는 통합 테스트 기반 클래스입니다.
  *
  * <p>컨테이너는 테스트 실행 시 한 번만 시작되며, 모든 하위 클래스가 공유합니다.
  *
@@ -47,7 +47,7 @@ public abstract class BaseIntegrationTest {
         .withEnv("xpack.security.enabled", "true")
         .withEnv("xpack.security.http.ssl.enabled", "false")
         .withEnv("xpack.security.transport.ssl.enabled", "false")
-        .withCommand("bash", "-c", 
+        .withCommand("bash", "-c",
 """
 if [ ! -d /usr/share/elasticsearch/plugins/analysis-nori ]; then
   bin/elasticsearch-plugin install analysis-nori --batch;
@@ -87,6 +87,7 @@ fi &&
         registry.add("spring.data.redis.host", redis::getHost);
         registry.add("spring.data.redis.port", redis::getRedisPort);
 
+        registry.add("spring.elasticsearch.username", ()-> "elastic" );
         registry.add("spring.elasticsearch.password", ()-> "1234" );
         registry.add("spring.elasticsearch.uris", elasticsearch::getHttpHostAddress);
     }

--- a/src/test/java/com/example/auction/testutils/BaseIntegrationTest.java
+++ b/src/test/java/com/example/auction/testutils/BaseIntegrationTest.java
@@ -4,6 +4,7 @@ import com.redis.testcontainers.RedisContainer;
 
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -38,6 +39,22 @@ public abstract class BaseIntegrationTest {
             DockerImageName.parse("redis:8.6.2")
     );
 
+    static ElasticsearchContainer elasticsearch = new ElasticsearchContainer(
+            DockerImageName.parse("elasticsearch:9.3.3")
+        )
+        .withPassword("1234")
+        .withEnv("discovery.type", "single-node")
+        .withEnv("xpack.security.enabled", "true")
+        .withEnv("xpack.security.http.ssl.enabled", "false")
+        .withEnv("xpack.security.transport.ssl.enabled", "false")
+        .withCommand("bash", "-c", 
+"""
+if [ ! -d /usr/share/elasticsearch/plugins/analysis-nori ]; then
+  bin/elasticsearch-plugin install analysis-nori --batch;
+fi &&
+/usr/local/bin/docker-entrypoint.sh
+""");
+
     static  {
         // Testcontainers는 기본적으로 테스트가 끝난후 테스트에 쓰인 container를 없애버립니다.
         // 
@@ -53,9 +70,11 @@ public abstract class BaseIntegrationTest {
         if (reuseEnabled) {
             postgres.withReuse(true).start();
             redis.withReuse(true).start();
+            elasticsearch.withReuse(true).start();
         }else {
             postgres.start();
             redis.start();
+            elasticsearch.start();
         }
     }
 
@@ -67,5 +86,8 @@ public abstract class BaseIntegrationTest {
 
         registry.add("spring.data.redis.host", redis::getHost);
         registry.add("spring.data.redis.port", redis::getRedisPort);
+
+        registry.add("spring.elasticsearch.password", ()-> "1234" );
+        registry.add("spring.elasticsearch.uris", elasticsearch::getHttpHostAddress);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 본인 경매 조회에 Elasticsearch를 도입
- 기본 경매 조회에 Elasticsearch를 도입
- 관리자 경매 조회에 Elasticsearch를 도입-

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항
Elasticsearch를 도입하면서 .env 파일에 새로 추가할 것들이 생겼습니다.
```
ELASTICSEARCH_URIS=http://auction-elasticsearch:9200
ELASTICSEARCH_PASSWORD=1234
```

기본적으로 검색 키워드가 없을 경우 기존 DB를 사용하고 검색 키워드가 있을 시 Elasticsearch를 사용 하도록 구현하였습니다.

단어를 이용한 검색이 실제로 기존 DB보다 낮다는 테스트는 작성하지 않았지만 기존 AuctionRepositoryTest.java에 있던 테스트를 그대로 porting 하여 DB 기존 DB가 하던 일을 Elasticsearch도 할 수 있다는 것을 증명했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 고급 검색 강화: 가격대·상태·카테고리·키워드 기반 검색 및 DB/검색엔진 간 자동 대체
  * 관리자용 검색/목록 필터링 기능 추가

* **인프라**
  * Elasticsearch 통합 및 Kibana 추가로 검색 인덱싱과 대시보드 지원
  * 애플리케이션 및 테스트 환경에 검색 연결 구성 추가

* **테스트**
  * Elasticsearch 기반 통합 테스트 추가 (검색 및 관리자 목록 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->