### PR TITLE
[FEAT] REST Docs 문서화 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,4 @@ application-local.yml
 .claude/
 CLAUDE.md
 
-### local docs ###
-docs/
-
 tmp/

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ java {
 repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://repo.spring.io/snapshot' }
+}
+
+asciidoctorj {
+    version = "3.0.0"
 }
 
 configurations {
@@ -93,8 +98,9 @@ dependencies {
     testImplementation "com.redis:testcontainers-redis:2.2.4"
 
     // REST Docs
-    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:4.0.0'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:4.0.0'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:4.0.1-SNAPSHOT'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:4.0.1-SNAPSHOT'
+    testImplementation 'org.springframework.boot:spring-boot-restdocs'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
@@ -118,8 +124,16 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-asciidoctor {
+tasks.named("asciidoctor") {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     dependsOn tasks.named('test')
+    baseDirFollowsSourceFile()
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from ("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '4.0.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id "org.asciidoctor.jvm.convert" version "4.0.5"
 }
 
 group = 'com.example'
@@ -17,6 +18,10 @@ java {
 repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' }
+}
+
+configurations {
+    asciidoctorExt
 }
 
 dependencyManagement {
@@ -87,6 +92,10 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers-elasticsearch"
     testImplementation "com.redis:testcontainers-redis:2.2.4"
 
+    // REST Docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:4.0.0'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:4.0.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
@@ -100,6 +109,17 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
 tasks.named('test') {
+    outputs.dir snippetsDir
     useJUnitPlatform()
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn tasks.named('test')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ java {
 repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' }
-    maven { url 'https://repo.spring.io/snapshot' }
 }
 
 asciidoctorj {
@@ -98,8 +97,8 @@ dependencies {
     testImplementation "com.redis:testcontainers-redis:2.2.4"
 
     // REST Docs
-    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:4.0.1-SNAPSHOT'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:4.0.1-SNAPSHOT'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:4.0.0'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:4.0.0'
     testImplementation 'org.springframework.boot:spring-boot-restdocs'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/docs/asciidoc/auction-admin.adoc
+++ b/src/docs/asciidoc/auction-admin.adoc
@@ -1,0 +1,13 @@
+== 경매 관리자 전용 API
+
+=== 경매 전체 조회 (취소 포함)
+==== 요청
+include::{snippets}/auction-admin/get-auction-list/http-request.adoc[]
+==== 응답
+include::{snippets}/auction-admin/get-auction-list/http-response.adoc[]
+
+=== 경매 강제 취소
+==== 요청
+include::{snippets}/auction-admin/force-cancel/http-request.adoc[]
+==== 응답
+include::{snippets}/auction-admin/force-cancel/http-response.adoc[]

--- a/src/docs/asciidoc/auction-admin.adoc
+++ b/src/docs/asciidoc/auction-admin.adoc
@@ -1,12 +1,20 @@
 == 경매 관리자 전용 API
 
 === 경매 전체 조회 (취소 포함)
+==== 요청 헤더
+include::{snippets}/auction-admin/get-auction-list/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/auction-admin/get-auction-list/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/auction-admin/get-auction-list/http-request.adoc[]
 ==== 응답
 include::{snippets}/auction-admin/get-auction-list/http-response.adoc[]
 
 === 경매 강제 취소
+==== 요청 헤더
+include::{snippets}/auction-admin/force-cancel/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/auction-admin/force-cancel/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/auction-admin/force-cancel/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/auction-result-admin.adoc
+++ b/src/docs/asciidoc/auction-result-admin.adoc
@@ -1,6 +1,10 @@
 == 경매 결과 관리자 전용 API
 
 === 경매 결과 목록 조회
+==== 요청 헤더
+include::{snippets}/auction-result-admin/get-auction-result-list/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/auction-result-admin/get-auction-result-list/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/auction-result-admin/get-auction-result-list/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/auction-result-admin.adoc
+++ b/src/docs/asciidoc/auction-result-admin.adoc
@@ -1,0 +1,7 @@
+== 경매 결과 관리자 전용 API
+
+=== 경매 결과 목록 조회
+==== 요청
+include::{snippets}/auction-result-admin/get-auction-result-list/http-request.adoc[]
+==== 응답
+include::{snippets}/auction-result-admin/get-auction-result-list/http-response.adoc[]

--- a/src/docs/asciidoc/auction.adoc
+++ b/src/docs/asciidoc/auction.adoc
@@ -1,0 +1,31 @@
+== 경매 API
+
+=== 경매 단건 조회
+==== 요청
+include::{snippets}/auction/get-auction/http-request.adoc[]
+==== 응답
+include::{snippets}/auction/get-auction/http-response.adoc[]
+
+=== 경매 전체 조회
+==== 요청
+include::{snippets}/auction/get-many-auctions-public/http-request.adoc[]
+==== 응답
+include::{snippets}/auction/get-many-auctions-public/http-response.adoc[]
+
+=== 내 경매 목록 조회
+==== 요청
+include::{snippets}/auction/get-many-auctions-me/http-request.adoc[]
+==== 응답
+include::{snippets}/auction/get-many-auctions-me/http-response.adoc[]
+
+=== 경매 생성
+==== 요청
+include::{snippets}/auction/create-auction/http-request.adoc[]
+==== 응답
+include::{snippets}/auction/create-auction/http-response.adoc[]
+
+=== 경매 취소
+==== 요청
+include::{snippets}/auction/cancel-auction/http-request.adoc[]
+==== 응답
+include::{snippets}/auction/cancel-auction/http-response.adoc[]

--- a/src/docs/asciidoc/auction.adoc
+++ b/src/docs/asciidoc/auction.adoc
@@ -29,6 +29,8 @@ include::{snippets}/auction/get-many-auctions-me/http-response.adoc[]
 === 경매 생성
 ==== 요청 헤더
 include::{snippets}/auction/create-auction/request-headers.adoc[]
+==== 요청 필드
+include::{snippets}/auction/create-auction/request-fields.adoc[]
 ==== 요청
 include::{snippets}/auction/create-auction/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/auction.adoc
+++ b/src/docs/asciidoc/auction.adoc
@@ -1,30 +1,44 @@
 == 경매 API
 
 === 경매 단건 조회
+==== Path Variable
+include::{snippets}/auction/get-auction/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/auction/get-auction/http-request.adoc[]
 ==== 응답
 include::{snippets}/auction/get-auction/http-response.adoc[]
 
 === 경매 전체 조회
+==== Query Parameter
+include::{snippets}/auction/get-many-auction-public/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/auction/get-many-auctions-public/http-request.adoc[]
 ==== 응답
 include::{snippets}/auction/get-many-auctions-public/http-response.adoc[]
 
 === 내 경매 목록 조회
+==== 요청 헤더
+include::{snippets}/auction/get-many-auctions-me/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/auction/get-many-auctions-me/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/auction/get-many-auctions-me/http-request.adoc[]
 ==== 응답
 include::{snippets}/auction/get-many-auctions-me/http-response.adoc[]
 
 === 경매 생성
+==== 요청 헤더
+include::{snippets}/auction/create-auction/request-headers.adoc[]
 ==== 요청
 include::{snippets}/auction/create-auction/http-request.adoc[]
 ==== 응답
 include::{snippets}/auction/create-auction/http-response.adoc[]
 
 === 경매 취소
+==== 요청 헤더
+include::{snippets}/auction/cancel-auction/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/auction/cancel-auction/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/auction/cancel-auction/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/auction.adoc
+++ b/src/docs/asciidoc/auction.adoc
@@ -10,7 +10,7 @@ include::{snippets}/auction/get-auction/http-response.adoc[]
 
 === 경매 전체 조회
 ==== Query Parameter
-include::{snippets}/auction/get-many-auction-public/query-parameters.adoc[]
+include::{snippets}/auction/get-many-auctions-public/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/auction/get-many-auctions-public/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/auth-admin.adoc
+++ b/src/docs/asciidoc/auth-admin.adoc
@@ -1,0 +1,7 @@
+== 인증/인가 관리자 전용 API
+
+=== 관리자 회원가입
+==== 요청
+include::{snippets}/auth-admin/signup/http-request.adoc[]
+==== 응답
+include::{snippets}/auth-admin/signup/http-response.adoc[]

--- a/src/docs/asciidoc/auth-admin.adoc
+++ b/src/docs/asciidoc/auth-admin.adoc
@@ -1,6 +1,8 @@
 == 인증/인가 관리자 전용 API
 
 === 관리자 회원가입
+==== 요청 필드
+include::{snippets}/auth-admin/signup/request-fields.adoc[]
 ==== 요청
 include::{snippets}/auth-admin/signup/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,25 @@
+== 인증/인가 API
+
+=== 회원가입
+==== 요청
+include::{snippets}/auth/signup/http-request.adoc[]
+==== 응답
+include::{snippets}/auth/signup/http-response.adoc[]
+
+=== 로그인
+==== 요청
+include::{snippets}/auth/login/http-request.adoc[]
+==== 응답
+include::{snippets}/auth/login/http-response.adoc[]
+
+=== 토큰 재발급
+==== 요청
+include::{snippets}/auth/refresh-token/http-request.adoc[]
+==== 응답
+include::{snippets}/auth/refresh-token/http-response.adoc[]
+
+=== 로그아웃
+==== 요청
+include::{snippets}/auth/logout/http-request.adoc[]
+==== 응답
+include::{snippets}/auth/logout/http-response.adoc[]

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -13,12 +13,16 @@ include::{snippets}/auth/login/http-request.adoc[]
 include::{snippets}/auth/login/http-response.adoc[]
 
 === 토큰 재발급
+==== 요청 헤더
+include::{snippets}/auth/refresh-token/request-headers.adoc[]
 ==== 요청
 include::{snippets}/auth/refresh-token/http-request.adoc[]
 ==== 응답
 include::{snippets}/auth/refresh-token/http-response.adoc[]
 
 === 로그아웃
+==== 요청 헤더
+include::{snippets}/auth/logout/request-headers.adoc[]
 ==== 요청
 include::{snippets}/auth/logout/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,12 +1,16 @@
 == 인증/인가 API
 
 === 회원가입
+==== 요청 필드
+include::{snippets}/auth/signup/request-fields.adoc[]
 ==== 요청
 include::{snippets}/auth/signup/http-request.adoc[]
 ==== 응답
 include::{snippets}/auth/signup/http-response.adoc[]
 
 === 로그인
+==== 요청 필드
+include::{snippets}/auth/login/request-fields.adoc[]
 ==== 요청
 include::{snippets}/auth/login/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/bid-admin.adoc
+++ b/src/docs/asciidoc/bid-admin.adoc
@@ -1,0 +1,13 @@
+== 입찰 관리자 전용 API
+
+=== 입찰 목록 조회 (취소 포함)
+==== 요청
+include::{snippets}/bid-admin/get-bid-list/http-request.adoc[]
+==== 응답
+include::{snippets}/bid-admin/get-bid-list/http-response.adoc[]
+
+=== 입찰 강제 취소
+==== 요청
+include::{snippets}/bid-admin/force-cancel/http-request.adoc[]
+==== 응답
+include::{snippets}/bid-admin/force-cancel/http-response.adoc[]

--- a/src/docs/asciidoc/bid-admin.adoc
+++ b/src/docs/asciidoc/bid-admin.adoc
@@ -1,12 +1,20 @@
 == 입찰 관리자 전용 API
 
 === 입찰 목록 조회 (취소 포함)
+==== 요청 헤더
+include::{snippets}/bid-admin/get-bid-list/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/bid-admin/get-bid-list/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/bid-admin/get-bid-list/http-request.adoc[]
 ==== 응답
 include::{snippets}/bid-admin/get-bid-list/http-response.adoc[]
 
 === 입찰 강제 취소
+==== 요청 헤더
+include::{snippets}/bid-admin/force-cancel/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/bid-admin/force-cancel/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/bid-admin/force-cancel/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/bid-user.adoc
+++ b/src/docs/asciidoc/bid-user.adoc
@@ -1,6 +1,10 @@
-== 입찰 유저 전용 API
+== 입찰 사용자 전용 API
 
 === 내 입찰 조회
+==== 요청 헤더
+include::{snippets}/bid-user/get-my-bids/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/bid-user/get-my-bids/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/bid-user/get-my-bids/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/bid-user.adoc
+++ b/src/docs/asciidoc/bid-user.adoc
@@ -1,0 +1,7 @@
+== 입찰 유저 전용 API
+
+=== 내 입찰 조회
+==== 요청
+include::{snippets}/bid-user/get-my-bids/http-request.adoc[]
+==== 응답
+include::{snippets}/bid-user/get-my-bids/http-response.adoc[]

--- a/src/docs/asciidoc/bid.adoc
+++ b/src/docs/asciidoc/bid.adoc
@@ -1,24 +1,42 @@
 == 입찰 API
 
 === 입찰 생성
+==== 요청 헤더
+include::{snippets}/bid/place-bid/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/bid/place-bid/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/bid/place-bid/http-request.adoc[]
 ==== 응답
 include::{snippets}/bid/place-bid/http-response.adoc[]
 
 === 입찰 목록 조회
+==== 요청 헤더
+include::{snippets}/bid/get-bids/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/bid/get-bids/path-parameters.adoc[]
+==== Query Parameter
+include::{snippets}/bid/get-bids/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/bid/get-bids/http-request.adoc[]
 ==== 응답
 include::{snippets}/bid/get-bids/http-response.adoc[]
 
 === 입찰 결과 조회
+==== 요청 헤더
+include::{snippets}/bid/get-winner-bid/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/bid/get-winner-bid/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/bid/get-winner-bid/http-request.adoc[]
 ==== 응답
 include::{snippets}/bid/get-winner-bid/http-response.adoc[]
 
 === 현재 최저가 입찰 조회
+==== 요청 헤더
+include::{snippets}/bid/get-current-min-bid/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/bid/get-current-min-bid/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/bid/get-current-min-bid/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/bid.adoc
+++ b/src/docs/asciidoc/bid.adoc
@@ -5,6 +5,8 @@
 include::{snippets}/bid/place-bid/request-headers.adoc[]
 ==== Path Variable
 include::{snippets}/bid/place-bid/path-parameters.adoc[]
+==== 요청 필드
+include::{snippets}/bid/place-bid/request-fields.adoc[]
 ==== 요청
 include::{snippets}/bid/place-bid/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/bid.adoc
+++ b/src/docs/asciidoc/bid.adoc
@@ -1,0 +1,25 @@
+== 입찰 API
+
+=== 입찰 생성
+==== 요청
+include::{snippets}/bid/place-bid/http-request.adoc[]
+==== 응답
+include::{snippets}/bid/place-bid/http-response.adoc[]
+
+=== 입찰 목록 조회
+==== 요청
+include::{snippets}/bid/get-bids/http-request.adoc[]
+==== 응답
+include::{snippets}/bid/get-bids/http-response.adoc[]
+
+=== 입찰 결과 조회
+==== 요청
+include::{snippets}/bid/get-winner-bid/http-request.adoc[]
+==== 응답
+include::{snippets}/bid/get-winner-bid/http-response.adoc[]
+
+=== 현재 최저가 입찰 조회
+==== 요청
+include::{snippets}/bid/get-current-min-bid/http-request.adoc[]
+==== 응답
+include::{snippets}/bid/get-current-min-bid/http-response.adoc[]

--- a/src/docs/asciidoc/category-admin.adoc
+++ b/src/docs/asciidoc/category-admin.adoc
@@ -3,6 +3,8 @@
 === 카테고리 생성
 ==== 요청 헤더
 include::{snippets}/category-admin/create-category/request-headers.adoc[]
+==== 요청 필드
+include::{snippets}/category-admin/create-category/request-fields.adoc[]
 ==== 요청
 include::{snippets}/category-admin/create-category/http-request.adoc[]
 ==== 응답
@@ -13,6 +15,8 @@ include::{snippets}/category-admin/create-category/http-response.adoc[]
 include::{snippets}/category-admin/rename-category/request-headers.adoc[]
 ==== Path Variable
 include::{snippets}/category-admin/rename-category/path-parameters.adoc[]
+==== 요청 필드
+include::{snippets}/category-admin/rename-category/request-fields.adoc[]
 ==== 요청
 include::{snippets}/category-admin/rename-category/http-request.adoc[]
 ==== 응답
@@ -23,6 +27,8 @@ include::{snippets}/category-admin/rename-category/http-response.adoc[]
 include::{snippets}/category-admin/move-category/request-headers.adoc[]
 ==== Path Variable
 include::{snippets}/category-admin/move-category/path-parameters.adoc[]
+==== 요청 필드
+include::{snippets}/category-admin/move-category/request-fields.adoc[]
 ==== 요청
 include::{snippets}/category-admin/move-category/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/category-admin.adoc
+++ b/src/docs/asciidoc/category-admin.adoc
@@ -1,0 +1,19 @@
+== 카테고리 관리자 전용 API
+
+=== 카테고리 생성
+==== 요청
+include::{snippets}/category-admin/create-category/http-request.adoc[]
+==== 응답
+include::{snippets}/category-admin/create-category/http-response.adoc[]
+
+=== 카테고리 이름 수정
+==== 요청
+include::{snippets}/category-admin/rename-category/http-request.adoc[]
+==== 응답
+include::{snippets}/category-admin/rename-category/http-response.adoc[]
+
+=== 카테고리 이동
+==== 요청
+include::{snippets}/category-admin/move-category/http-request.adoc[]
+==== 응답
+include::{snippets}/category-admin/move-category/http-response.adoc[]

--- a/src/docs/asciidoc/category-admin.adoc
+++ b/src/docs/asciidoc/category-admin.adoc
@@ -1,18 +1,28 @@
 == 카테고리 관리자 전용 API
 
 === 카테고리 생성
+==== 요청 헤더
+include::{snippets}/category-admin/create-category/request-headers.adoc[]
 ==== 요청
 include::{snippets}/category-admin/create-category/http-request.adoc[]
 ==== 응답
 include::{snippets}/category-admin/create-category/http-response.adoc[]
 
 === 카테고리 이름 수정
+==== 요청 헤더
+include::{snippets}/category-admin/rename-category/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/category-admin/rename-category/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/category-admin/rename-category/http-request.adoc[]
 ==== 응답
 include::{snippets}/category-admin/rename-category/http-response.adoc[]
 
 === 카테고리 이동
+==== 요청 헤더
+include::{snippets}/category-admin/move-category/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/category-admin/move-category/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/category-admin/move-category/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/category.adoc
+++ b/src/docs/asciidoc/category.adoc
@@ -1,0 +1,7 @@
+== 카테고리 API
+
+=== 카테고리 목록 조회
+==== 요청
+include::{snippets}/category/get-category-list/http-request.adoc[]
+==== 응답
+include::{snippets}/category/get-category-list/http-response.adoc[]

--- a/src/docs/asciidoc/chat.adoc
+++ b/src/docs/asciidoc/chat.adoc
@@ -1,30 +1,50 @@
 == 채팅 API
 
 === 채팅방 생성
+==== 요청 헤더
+include::{snippets}/chat/create-room/request-headers.adoc[]
 ==== 요청
 include::{snippets}/chat/create-room/http-request.adoc[]
 ==== 응답
 include::{snippets}/chat/create-room/http-response.adoc[]
 
 === 채팅방 목록 조회
+==== 요청 헤더
+include::{snippets}/chat/get-rooms/request-headers.adoc[]
 ==== 요청
 include::{snippets}/chat/get-rooms/http-request.adoc[]
 ==== 응답
 include::{snippets}/chat/get-rooms/http-response.adoc[]
 
 === 채팅방 제목 수정
+==== 요청 헤더
+include::{snippets}/chat/update-room/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/chat/update-room/path-parameters.adoc[]
+==== 요청 필드
+include::{snippets}/chat/update-room/request-fields.adoc[]
 ==== 요청
 include::{snippets}/chat/update-room/http-request.adoc[]
 ==== 응답
 include::{snippets}/chat/update-room/http-response.adoc[]
 
 === 채팅방 삭제
+==== 요청 헤더
+include::{snippets}/chat/delete-room/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/chat/delete-room/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/chat/delete-room/http-request.adoc[]
 ==== 응답
 include::{snippets}/chat/delete-room/http-response.adoc[]
 
 === 메시지 목록 조회
+==== 요청 헤더
+include::{snippets}/chat/get-messages/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/chat/get-messages/path-parameters.adoc[]
+==== Query Parameter
+include::{snippets}/chat/get-messages/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/chat/get-messages/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/chat.adoc
+++ b/src/docs/asciidoc/chat.adoc
@@ -1,0 +1,31 @@
+== 채팅 API
+
+=== 채팅방 생성
+==== 요청
+include::{snippets}/chat/create-room/http-request.adoc[]
+==== 응답
+include::{snippets}/chat/create-room/http-response.adoc[]
+
+=== 채팅방 목록 조회
+==== 요청
+include::{snippets}/chat/get-rooms/http-request.adoc[]
+==== 응답
+include::{snippets}/chat/get-rooms/http-response.adoc[]
+
+=== 채팅방 제목 수정
+==== 요청
+include::{snippets}/chat/update-room/http-request.adoc[]
+==== 응답
+include::{snippets}/chat/update-room/http-response.adoc[]
+
+=== 채팅방 삭제
+==== 요청
+include::{snippets}/chat/delete-room/http-request.adoc[]
+==== 응답
+include::{snippets}/chat/delete-room/http-response.adoc[]
+
+=== 메시지 목록 조회
+==== 요청
+include::{snippets}/chat/get-messages/http-request.adoc[]
+==== 응답
+include::{snippets}/chat/get-messages/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,21 @@
+= Second-Hand Goods Reverse Auction
+:doctype: book
+:toc: left
+:toc-title: 목차
+
+include::auth.adoc[]
+include::user.adoc[]
+include::auction.adoc[]
+include::bid.adoc[]
+include::bid-user.adoc[]
+include::category.adoc[]
+include::review.adoc[]
+include::chat.adoc[]
+
+include::auth-admin.adoc[]
+include::user-admin.adoc[]
+include::auction-admin.adoc[]
+include::auction-result-admin.adoc[]
+include::bid-admin.adoc[]
+include::category-admin.adoc[]
+include::review-admin.adoc[]

--- a/src/docs/asciidoc/review-admin.adoc
+++ b/src/docs/asciidoc/review-admin.adoc
@@ -1,0 +1,13 @@
+== 리뷰 관리자 전용 API
+
+=== 리뷰 목록 조회
+==== 요청
+include::{snippets}/review-admin/get-review-list/http-request.adoc[]
+==== 응답
+include::{snippets}/review-admin/get-review-list/http-response.adoc[]
+
+=== 리뷰 강제 삭제
+==== 요청
+include::{snippets}/review-admin/force-delete/http-request.adoc[]
+==== 응답
+include::{snippets}/review-admin/force-delete/http-response.adoc[]

--- a/src/docs/asciidoc/review-admin.adoc
+++ b/src/docs/asciidoc/review-admin.adoc
@@ -1,12 +1,20 @@
 == 리뷰 관리자 전용 API
 
 === 리뷰 목록 조회
+==== 요청 헤더
+include::{snippets}/review-admin/get-review-list/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/review-admin/get-review-list/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/review-admin/get-review-list/http-request.adoc[]
 ==== 응답
 include::{snippets}/review-admin/get-review-list/http-response.adoc[]
 
 === 리뷰 강제 삭제
+==== 요청 헤더
+include::{snippets}/review-admin/force-delete/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/review-admin/force-delete/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/review-admin/force-delete/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/review.adoc
+++ b/src/docs/asciidoc/review.adoc
@@ -1,0 +1,37 @@
+== 리뷰 API
+
+=== 리뷰 생성
+==== 요청
+include::{snippets}/review/create-review/http-request.adoc[]
+==== 응답
+include::{snippets}/review/create-review/http-response.adoc[]
+
+=== 작성한 리뷰 목록 조회
+==== 요청
+include::{snippets}/review/get-written-review-list/http-request.adoc[]
+==== 응답
+include::{snippets}/review/get-written-review-list/http-response.adoc[]
+
+=== 받은 리뷰 목록 조회
+==== 요청
+include::{snippets}/review/get-received-review-list/http-request.adoc[]
+==== 응답
+include::{snippets}/review/get-received-review-list/http-response.adoc[]
+
+=== 리뷰 상세 조회
+==== 요청
+include::{snippets}/review/get-review/http-request.adoc[]
+==== 응답
+include::{snippets}/review/get-review/http-response.adoc[]
+
+=== 리뷰 수정
+==== 요청
+include::{snippets}/review/modify-review/http-request.adoc[]
+==== 응답
+include::{snippets}/review/modify-review/http-response.adoc[]
+
+=== 리뷰 삭제
+==== 요청
+include::{snippets}/review/delete-review/http-request.adoc[]
+==== 응답
+include::{snippets}/review/delete-review/http-response.adoc[]

--- a/src/docs/asciidoc/review.adoc
+++ b/src/docs/asciidoc/review.adoc
@@ -3,6 +3,8 @@
 === 리뷰 생성
 ==== 요청 헤더
 include::{snippets}/review/create-review/request-headers.adoc[]
+==== 요청 필드
+include::{snippets}/review/create-review/request-fields.adoc[]
 ==== 요청
 include::{snippets}/review/create-review/http-request.adoc[]
 ==== 응답
@@ -41,6 +43,8 @@ include::{snippets}/review/get-review/http-response.adoc[]
 include::{snippets}/review/modify-review/request-headers.adoc[]
 ==== Path Variable
 include::{snippets}/review/modify-review/path-parameters.adoc[]
+==== 요청 필드
+include::{snippets}/review/modify-review/request-fields.adoc[]
 ==== 요청
 include::{snippets}/review/modify-review/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/review.adoc
+++ b/src/docs/asciidoc/review.adoc
@@ -1,36 +1,56 @@
 == 리뷰 API
 
 === 리뷰 생성
+==== 요청 헤더
+include::{snippets}/review/create-review/request-headers.adoc[]
 ==== 요청
 include::{snippets}/review/create-review/http-request.adoc[]
 ==== 응답
 include::{snippets}/review/create-review/http-response.adoc[]
 
 === 작성한 리뷰 목록 조회
+==== 요청 헤더
+include::{snippets}/review/get-written-review-list/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/review/get-written-review-list/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/review/get-written-review-list/http-request.adoc[]
 ==== 응답
 include::{snippets}/review/get-written-review-list/http-response.adoc[]
 
 === 받은 리뷰 목록 조회
+==== 요청 헤더
+include::{snippets}/review/get-received-review-list/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/review/get-received-review-list/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/review/get-received-review-list/http-request.adoc[]
 ==== 응답
 include::{snippets}/review/get-received-review-list/http-response.adoc[]
 
 === 리뷰 상세 조회
+==== Path Variable
+include::{snippets}/review/get-review/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/review/get-review/http-request.adoc[]
 ==== 응답
 include::{snippets}/review/get-review/http-response.adoc[]
 
 === 리뷰 수정
+==== 요청 헤더
+include::{snippets}/review/modify-review/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/review/modify-review/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/review/modify-review/http-request.adoc[]
 ==== 응답
 include::{snippets}/review/modify-review/http-response.adoc[]
 
 === 리뷰 삭제
+==== 요청 헤더
+include::{snippets}/review/delete-review/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/review/delete-review/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/review/delete-review/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/review.adoc
+++ b/src/docs/asciidoc/review.adoc
@@ -1,5 +1,15 @@
 == 리뷰 API
 
+=== 리뷰 이미지 업로드 URL 발급
+==== 요청 헤더
+include::{snippets}/review/get-presigned-url/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/review/get-presigned-url/query-parameters.adoc[]
+==== 요청
+include::{snippets}/review/get-presigned-url/http-request.adoc[]
+==== 응답
+include::{snippets}/review/get-presigned-url/http-response.adoc[]
+
 === 리뷰 생성
 ==== 요청 헤더
 include::{snippets}/review/create-review/request-headers.adoc[]

--- a/src/docs/asciidoc/user-admin.adoc
+++ b/src/docs/asciidoc/user-admin.adoc
@@ -1,0 +1,19 @@
+== 사용자 관리자 전용API
+
+=== 사용자 목록 조회
+==== 요청
+include::{snippets}/user-admin/get-user-list/http-request.adoc[]
+==== 응답
+include::{snippets}/user-admin/get-user-list/http-response.adoc[]
+
+=== 사용자 상세 조회
+==== 요청
+include::{snippets}/user-admin/get-user-detail/http-request.adoc[]
+==== 응답
+include::{snippets}/user-admin/get-user-detail/http-response.adoc[]
+
+=== 사용자 강제 탈퇴
+==== 요청
+include::{snippets}/user-admin/force-withdraw/http-request.adoc[]
+==== 응답
+include::{snippets}/user-admin/force-withdraw/http-response.adoc[]

--- a/src/docs/asciidoc/user-admin.adoc
+++ b/src/docs/asciidoc/user-admin.adoc
@@ -1,18 +1,30 @@
 == 사용자 관리자 전용API
 
 === 사용자 목록 조회
+==== 요청 헤더
+include::{snippets}/user-admin/get-user-list/request-headers.adoc[]
+==== Query Parameter
+include::{snippets}/user-admin/get-user-list/query-parameters.adoc[]
 ==== 요청
 include::{snippets}/user-admin/get-user-list/http-request.adoc[]
 ==== 응답
 include::{snippets}/user-admin/get-user-list/http-response.adoc[]
 
 === 사용자 상세 조회
+==== 요청 헤더
+include::{snippets}/user-admin/get-user-detail/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/user-admin/get-user-detail/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/user-admin/get-user-detail/http-request.adoc[]
 ==== 응답
 include::{snippets}/user-admin/get-user-detail/http-response.adoc[]
 
 === 사용자 강제 탈퇴
+==== 요청 헤더
+include::{snippets}/user-admin/force-withdraw/request-headers.adoc[]
+==== Path Variable
+include::{snippets}/user-admin/force-withdraw/path-parameters.adoc[]
 ==== 요청
 include::{snippets}/user-admin/force-withdraw/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -1,18 +1,24 @@
 == 사용자 API
 
 === 마이페이지 조회
+==== 요청 헤더
+include::{snippets}/user/my-page/request-headers.adoc[]
 ==== 요청
 include::{snippets}/user/my-page/http-request.adoc[]
 ==== 응답
 include::{snippets}/user/my-page/http-response.adoc[]
 
 === 비밀번호 변경
+==== 요청 헤더
+include::{snippets}/user/change-password/request-headers.adoc[]
 ==== 요청
 include::{snippets}/user/change-password/http-request.adoc[]
 ==== 응답
 include::{snippets}/user/change-password/http-response.adoc[]
 
 === 회원탈퇴
+==== 요청 헤더
+include::{snippets}/user/withdraw/request-headers.adoc[]
 ==== 요청
 include::{snippets}/user/withdraw/http-request.adoc[]
 ==== 응답

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -1,0 +1,19 @@
+== 사용자 API
+
+=== 마이페이지 조회
+==== 요청
+include::{snippets}/user/my-page/http-request.adoc[]
+==== 응답
+include::{snippets}/user/my-page/http-response.adoc[]
+
+=== 비밀번호 변경
+==== 요청
+include::{snippets}/user/change-password/http-request.adoc[]
+==== 응답
+include::{snippets}/user/change-password/http-response.adoc[]
+
+=== 회원탈퇴
+==== 요청
+include::{snippets}/user/withdraw/http-request.adoc[]
+==== 응답
+include::{snippets}/user/withdraw/http-response.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -11,6 +11,8 @@ include::{snippets}/user/my-page/http-response.adoc[]
 === 비밀번호 변경
 ==== 요청 헤더
 include::{snippets}/user/change-password/request-headers.adoc[]
+==== 요청 필드
+include::{snippets}/user/change-password/request-fields.adoc[]
 ==== 요청
 include::{snippets}/user/change-password/http-request.adoc[]
 ==== 응답

--- a/src/main/java/com/example/auction/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/auction/common/config/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                         .requestMatchers("/health").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/actuator/prometheus").permitAll()
+                        .requestMatchers("/docs/**").permitAll()
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/example/auction/domain/auction/dto/AuctionAdminSearchCondition.java
+++ b/src/main/java/com/example/auction/domain/auction/dto/AuctionAdminSearchCondition.java
@@ -18,6 +18,6 @@ public class AuctionAdminSearchCondition {
     @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다")
     private int size = 20;
 
-    private AuctionStatus auctionStatus;
+    private AuctionStatus status;
     private String keyword;
 }

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionAdminService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionAdminService.java
@@ -29,7 +29,7 @@ public class AuctionAdminService {
     public PageResponse<AuctionAdminListResponse> getAuctionList(AuctionAdminSearchCondition condition) {
         Page<AuctionAdminListResponse> auctionList = auctionSearchService.searchAuctionWithConditions(
                 PageRequest.of(condition.getPage(), condition.getSize()),
-                condition.getAuctionStatus(),
+                condition.getStatus(),
                 condition.getKeyword()
         );
 

--- a/src/main/java/com/example/auction/domain/user/controller/UserAdminController.java
+++ b/src/main/java/com/example/auction/domain/user/controller/UserAdminController.java
@@ -25,7 +25,7 @@ public class UserAdminController {
             @Valid @ModelAttribute UserSearchCondition condition
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
-                HttpStatus.OK.name(), "유저 목록 조회 요청 성공", userAdminService.getUserList(condition)));
+                HttpStatus.OK.name(), "사용자 목록 조회 요청 성공", userAdminService.getUserList(condition)));
     }
 
     @GetMapping("/{userId}")
@@ -33,7 +33,7 @@ public class UserAdminController {
             @PathVariable Long userId
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
-                HttpStatus.OK.name(), "유저 상세 조회 요청 성공", userAdminService.getUserDetail(userId)));
+                HttpStatus.OK.name(), "사용자 상세 조회 요청 성공", userAdminService.getUserDetail(userId)));
     }
 
     @DeleteMapping("/{userId}")
@@ -41,6 +41,6 @@ public class UserAdminController {
             @PathVariable Long userId
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(
-                HttpStatus.OK.name(), "유저 강제 탈퇴 요청 성공", userAdminService.forceWithdraw(userId)));
+                HttpStatus.OK.name(), "사용자 강제 탈퇴 요청 성공", userAdminService.forceWithdraw(userId)));
     }
 }

--- a/src/test/java/com/example/auction/domain/auction/controller/AuctionAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/controller/AuctionAdminControllerTest.java
@@ -11,25 +11,32 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({AuctionAdminController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class AuctionAdminControllerTest {
 
     @Autowired
@@ -76,7 +83,11 @@ class AuctionAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 목록 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.content.length()").value(3))
-                .andExpect(jsonPath("$.data.totalElements").value(3));
+                .andExpect(jsonPath("$.data.totalElements").value(3))
+                .andDo(document("auction-admin/get-auction-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));;
     }
 
     @Test
@@ -110,5 +121,29 @@ class AuctionAdminControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.message").value("페이지 크기는 100 이하여야 합니다"));
+    }
+
+
+    // ========================
+    // 경매 강제 취소
+    // ========================
+
+    @Test
+    @DisplayName("경매 강제 취소 성공")
+    void forceCancel_success() throws Exception {
+        // given
+        doNothing().when(auctionAdminService).forceCancel(1L);
+
+        // when & then
+        mockMvc.perform(delete("/api/admin/auctions/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("경매 강제 취소 요청 성공"))
+                .andDo(document("auction-admin/force-cancel",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));;;
+
+        verify(auctionAdminService).forceCancel(1L);
     }
 }

--- a/src/test/java/com/example/auction/domain/auction/controller/AuctionAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/controller/AuctionAdminControllerTest.java
@@ -26,9 +26,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -78,7 +81,10 @@ class AuctionAdminControllerTest {
         given(auctionAdminService.getAuctionList(any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/admin/auctions"))
+        mockMvc.perform(get("/api/admin/auctions")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 목록 조회 요청 성공"))
@@ -86,7 +92,14 @@ class AuctionAdminControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(3))
                 .andDo(document("auction-admin/get-auction-list",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)").optional(),
+                                parameterWithName("status").description("경매 상태 필터 (READY / ACTIVE / CLOSED / CANCELLED)").optional(),
+                                parameterWithName("keyword").description("검색 키워드").optional()
+                        )
                 ));;
     }
 
@@ -135,14 +148,17 @@ class AuctionAdminControllerTest {
         doNothing().when(auctionAdminService).forceCancel(1L);
 
         // when & then
-        mockMvc.perform(delete("/api/admin/auctions/1"))
+        mockMvc.perform(delete("/api/admin/auctions/{auctionId}", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 강제 취소 요청 성공"))
                 .andDo(document("auction-admin/force-cancel",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
-                ));;;
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        pathParameters(parameterWithName("auctionId").description("경매 식별자"))
+                ));
 
         verify(auctionAdminService).forceCancel(1L);
     }

--- a/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
@@ -1,0 +1,280 @@
+package com.example.auction.domain.auction.controller;
+
+import com.example.auction.common.config.security.CustomUserDetails;
+import com.example.auction.common.dto.PageResponse;
+import com.example.auction.common.exception.GlobalExceptionHandler;
+import com.example.auction.domain.auction.dto.CreateAuctionRequest;
+import com.example.auction.domain.auction.dto.GetAuctionResponse;
+import com.example.auction.domain.auction.dto.GetManyAuctionsResponse;
+import com.example.auction.domain.auction.enums.AuctionStatus;
+import com.example.auction.domain.auction.service.AuctionService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({AuctionController.class, GlobalExceptionHandler.class})
+@AutoConfigureMockMvc(addFilters = false)
+class AuctionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuctionService auctionService;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        CustomUserDetails userDetails = new CustomUserDetails(1L, "USER");
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+
+    // ========================
+    // 경매 단건 조회
+    // ========================
+
+    @Test
+    @DisplayName("경매 단건 조회 성공")
+    void getAuction_success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        GetAuctionResponse response = new GetAuctionResponse(
+                1L, 1L, "좋은 상품입니다", BigDecimal.valueOf(50000), "맥북 프로",
+                AuctionStatus.ACTIVE, now, now.plusDays(1), null, 1L, now);
+
+        given(auctionService.getAuction(1L)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/auctions/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("경매 단건조회를 하였습니다"))
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.itemName").value("맥북 프로"));
+    }
+
+
+    // ========================
+    // 경매 전체 조회 (공개)
+    // ========================
+
+    @Test
+    @DisplayName("경매 전체 조회 성공")
+    void getManyAuctionsPublic_success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PageResponse<GetManyAuctionsResponse> response = new PageResponse<>(
+                List.of(
+                        new GetManyAuctionsResponse(1L, 1L, BigDecimal.valueOf(50000), "맥북 프로", AuctionStatus.ACTIVE, now, now.plusDays(1), null, 1L, now),
+                        new GetManyAuctionsResponse(2L, 2L, BigDecimal.valueOf(30000), "아이패드", AuctionStatus.READY, now, now.plusDays(2), null, 2L, now)
+                ), 0, 1, 2L, 10, true);
+
+        given(auctionService.getManyAuctionsPublic(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/auctions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("경매 전체 조회를 하였습니다"))
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("경매 전체 조회 실패 - page 음수")
+    void getManyAuctionsPublic_fail_pageIsNegative() throws Exception {
+        mockMvc.perform(get("/api/auctions").param("page", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지는 0 이상이어야 합니다"));
+    }
+
+    @Test
+    @DisplayName("경매 전체 조회 실패 - pageSize 0")
+    void getManyAuctionsPublic_fail_pageSizeIsZero() throws Exception {
+        mockMvc.perform(get("/api/auctions").param("pageSize", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지 크기는 1 이상이어야 합니다"));
+    }
+
+    @Test
+    @DisplayName("경매 전체 조회 실패 - pageSize 100 초과")
+    void getManyAuctionsPublic_fail_pageSizeTooLarge() throws Exception {
+        mockMvc.perform(get("/api/auctions").param("pageSize", "101"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지 크기는 100 이하여야 합니다"));
+    }
+
+
+    // ========================
+    // 내 경매 목록 조회
+    // ========================
+
+    @Test
+    @DisplayName("내 경매 목록 조회 성공")
+    void getManyAuctionsMe_success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PageResponse<GetManyAuctionsResponse> response = new PageResponse<>(
+                List.of(
+                        new GetManyAuctionsResponse(1L, 1L, BigDecimal.valueOf(50000), "맥북 프로", AuctionStatus.ACTIVE, now, now.plusDays(1), null, 1L, now)
+                ), 0, 1, 1L, 10, true);
+
+        given(auctionService.getManyAuctionsMe(any(), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/me/auctions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("경매 전체 조회를 하였습니다"))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("내 경매 목록 조회 실패 - page 음수")
+    void getManyAuctionsMe_fail_pageIsNegative() throws Exception {
+        mockMvc.perform(get("/api/me/auctions").param("page", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지는 0 이상이어야 합니다"));
+    }
+
+
+    // ========================
+    // 경매 생성
+    // ========================
+
+    @Test
+    @DisplayName("경매 생성 성공")
+    void createAuction_success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        CreateAuctionRequest request = new CreateAuctionRequest();
+        request.setItemName("맥북 프로");
+        request.setDescription("좋은 상품입니다");
+        request.setMaxPrice(BigDecimal.valueOf(50000));
+        request.setCategoryId(1L);
+        request.setStartedAt(now.plusHours(1));
+        request.setEndedAt(now.plusDays(1));
+
+        GetAuctionResponse response = new GetAuctionResponse(
+                1L, 1L, "좋은 상품입니다", BigDecimal.valueOf(50000), "맥북 프로",
+                AuctionStatus.READY, now.plusHours(1), now.plusDays(1), null, 1L, now);
+
+        given(auctionService.createAuction(any(), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/auctions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("경매를 생성 하였습니다"))
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.itemName").value("맥북 프로"));
+    }
+
+    @Test
+    @DisplayName("경매 생성 실패 - 상품명 없음")
+    void createAuction_fail_itemNameBlank() throws Exception {
+        CreateAuctionRequest request = new CreateAuctionRequest();
+        request.setItemName("");
+        request.setMaxPrice(BigDecimal.valueOf(50000));
+        request.setCategoryId(1L);
+        request.setStartedAt(LocalDateTime.now().plusHours(1));
+        request.setEndedAt(LocalDateTime.now().plusDays(1));
+
+        mockMvc.perform(post("/api/auctions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("경매 상품 이름은 필수입니다"));
+    }
+
+    @Test
+    @DisplayName("경매 생성 실패 - 상품명 256자 초과")
+    void createAuction_fail_itemNameTooLong() throws Exception {
+        CreateAuctionRequest request = new CreateAuctionRequest();
+        request.setItemName("a".repeat(257));
+        request.setMaxPrice(BigDecimal.valueOf(50000));
+        request.setCategoryId(1L);
+        request.setStartedAt(LocalDateTime.now().plusHours(1));
+        request.setEndedAt(LocalDateTime.now().plusDays(1));
+
+        mockMvc.perform(post("/api/auctions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("경매 상품 이름이 너무 깁니다"));
+    }
+
+    @Test
+    @DisplayName("경매 생성 실패 - 최고가 0 이하")
+    void createAuction_fail_maxPriceNotPositive() throws Exception {
+        CreateAuctionRequest request = new CreateAuctionRequest();
+        request.setItemName("맥북 프로");
+        request.setMaxPrice(BigDecimal.ZERO);
+        request.setCategoryId(1L);
+        request.setStartedAt(LocalDateTime.now().plusHours(1));
+        request.setEndedAt(LocalDateTime.now().plusDays(1));
+
+        mockMvc.perform(post("/api/auctions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("경매 상품의 가격은 0보다 커야합니다"));
+    }
+
+
+    // ========================
+    // 경매 취소
+    // ========================
+
+    @Test
+    @DisplayName("경매 취소 성공")
+    void cancelAuction_success() throws Exception {
+        doNothing().when(auctionService).cancelAuction(eq(1L), any());
+
+        mockMvc.perform(delete("/api/auctions/1"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
@@ -36,6 +36,8 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -256,7 +258,15 @@ class AuctionControllerTest {
                 .andDo(document("auction/create-auction",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        requestFields(
+                                fieldWithPath("itemName").description("상품명 (256자 이하)"),
+                                fieldWithPath("description").description("상품 설명 (1024자 이하)").optional(),
+                                fieldWithPath("maxPrice").description("최고 가격 (0 초과)"),
+                                fieldWithPath("categoryId").description("카테고리 식별자 (1 이상)"),
+                                fieldWithPath("startedAt").description("경매 시작일"),
+                                fieldWithPath("endedAt").description("경매 종료일")
+                        )
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -30,7 +31,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -38,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest({AuctionController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class AuctionControllerTest {
 
     @Autowired
@@ -83,7 +87,11 @@ class AuctionControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 단건조회를 하였습니다"))
                 .andExpect(jsonPath("$.data.id").value(1L))
-                .andExpect(jsonPath("$.data.itemName").value("맥북 프로"));
+                .andExpect(jsonPath("$.data.itemName").value("맥북 프로"))
+                .andDo(document("auction/get-auction",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
 
@@ -110,7 +118,11 @@ class AuctionControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 전체 조회를 하였습니다"))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andDo(document("auction/get-many-auctions-public",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -163,7 +175,11 @@ class AuctionControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 전체 조회를 하였습니다"))
                 .andExpect(jsonPath("$.data.content.length()").value(1))
-                .andExpect(jsonPath("$.data.totalElements").value(1));
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andDo(document("auction/get-many-auctions-me",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -207,7 +223,11 @@ class AuctionControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매를 생성 하였습니다"))
                 .andExpect(jsonPath("$.data.id").value(1L))
-                .andExpect(jsonPath("$.data.itemName").value("맥북 프로"));
+                .andExpect(jsonPath("$.data.itemName").value("맥북 프로"))
+                .andDo(document("auction/create-auction",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -275,6 +295,10 @@ class AuctionControllerTest {
         doNothing().when(auctionService).cancelAuction(eq(1L), any());
 
         mockMvc.perform(delete("/api/auctions/1"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNoContent())
+                .andDo(document("auction/cancel-auction",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 }

--- a/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
@@ -247,7 +247,7 @@ class AuctionControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auctions")
-                        .header("Authorization", "Bearer accessTokekn")
+                        .header("Authorization", "Bearer accessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())

--- a/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/controller/AuctionControllerTest.java
@@ -31,9 +31,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -82,7 +85,7 @@ class AuctionControllerTest {
         given(auctionService.getAuction(1L)).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/auctions/1"))
+        mockMvc.perform(get("/api/auctions/{auctionId}", 1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 단건조회를 하였습니다"))
@@ -90,7 +93,8 @@ class AuctionControllerTest {
                 .andExpect(jsonPath("$.data.itemName").value("맥북 프로"))
                 .andDo(document("auction/get-auction",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(parameterWithName("auctionId").description("경매 식별자"))
                 ));
     }
 
@@ -113,7 +117,9 @@ class AuctionControllerTest {
         given(auctionService.getManyAuctionsPublic(any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/auctions"))
+        mockMvc.perform(get("/api/auctions")
+                        .param("page", "0")
+                        .param("pageSize", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 전체 조회를 하였습니다"))
@@ -121,7 +127,16 @@ class AuctionControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andDo(document("auction/get-many-auctions-public",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("keyword").description("검색 키워드").optional(),
+                                parameterWithName("maxPriceMin").description("최소 금액 (0 이상)").optional(),
+                                parameterWithName("maxPriceMax").description("최대 금액 (0 초과)").optional(),
+                                parameterWithName("status").description("경매 상태 필터 (READY / ACTIVE / CLOSED / CANCELLED)").optional(),
+                                parameterWithName("categoryId").description("카테고리 식별자 (1 이상)").optional(),
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("pageSize").description("페이지 크기 (1 ~ 100)").optional()
+                        )
                 ));
     }
 
@@ -170,7 +185,10 @@ class AuctionControllerTest {
         given(auctionService.getManyAuctionsMe(any(), any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/me/auctions"))
+        mockMvc.perform(get("/api/me/auctions")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("pageSize", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 전체 조회를 하였습니다"))
@@ -178,7 +196,17 @@ class AuctionControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(1))
                 .andDo(document("auction/get-many-auctions-me",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        queryParameters(
+                                parameterWithName("keyword").description("검색 키워드").optional(),
+                                parameterWithName("maxPriceMin").description("최소 금액 (0 이상)").optional(),
+                                parameterWithName("maxPriceMax").description("최대 금액 (0 초과)").optional(),
+                                parameterWithName("status").description("경매 상태 필터 (READY / ACTIVE / CLOSED / CANCELLED)").optional(),
+                                parameterWithName("categoryId").description("카테고리 식별자 (1 이상)").optional(),
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("pageSize").description("페이지 크기 (1 ~ 100)").optional()
+                        )
                 ));
     }
 
@@ -217,6 +245,7 @@ class AuctionControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auctions")
+                        .header("Authorization", "Bearer accessTokekn")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -226,7 +255,8 @@ class AuctionControllerTest {
                 .andExpect(jsonPath("$.data.itemName").value("맥북 프로"))
                 .andDo(document("auction/create-auction",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
                 ));
     }
 
@@ -294,11 +324,14 @@ class AuctionControllerTest {
     void cancelAuction_success() throws Exception {
         doNothing().when(auctionService).cancelAuction(eq(1L), any());
 
-        mockMvc.perform(delete("/api/auctions/1"))
+        mockMvc.perform(delete("/api/auctions/{auctionId}", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isNoContent())
                 .andDo(document("auction/cancel-auction",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("auctionId").description("경매 식별자"))
                 ));
     }
 }

--- a/src/test/java/com/example/auction/domain/auction/result/controller/AuctionResultAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/result/controller/AuctionResultAdminControllerTest.java
@@ -24,9 +24,13 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -73,7 +77,10 @@ class AuctionResultAdminControllerTest {
         given(auctionResultAdminService.getAuctionResultList(any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/admin/auction-results"))
+        mockMvc.perform(get("/api/admin/auction-results")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 결과 목록 조회 요청 성공"))
@@ -81,7 +88,12 @@ class AuctionResultAdminControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andDo(document("auction-result-admin/get-auction-result-list",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional()
+                        )
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/auction/result/controller/AuctionResultAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/result/controller/AuctionResultAdminControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -23,12 +24,16 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({AuctionResultAdminController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class AuctionResultAdminControllerTest {
 
     @Autowired
@@ -73,7 +78,11 @@ class AuctionResultAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("경매 결과 목록 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andDo(document("auction-result-admin/get-auction-result-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test

--- a/src/test/java/com/example/auction/domain/auction/result/controller/AuctionResultAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/result/controller/AuctionResultAdminControllerTest.java
@@ -1,0 +1,111 @@
+package com.example.auction.domain.auction.result.controller;
+
+import com.example.auction.common.config.security.CustomUserDetails;
+import com.example.auction.common.dto.PageResponse;
+import com.example.auction.common.exception.GlobalExceptionHandler;
+import com.example.auction.domain.auction.result.dto.AuctionResultAdminListResponse;
+import com.example.auction.domain.auction.result.service.AuctionResultAdminService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({AuctionResultAdminController.class, GlobalExceptionHandler.class})
+@AutoConfigureMockMvc(addFilters = false)
+class AuctionResultAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuctionResultAdminService auctionResultAdminService;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        CustomUserDetails userDetails = new CustomUserDetails(1L, "ADMIN");
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+
+    // ========================
+    // 경매 결과 목록 조회
+    // ========================
+
+    @Test
+    @DisplayName("경매 결과 목록 조회 성공")
+    void getAuctionResultList_success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PageResponse<AuctionResultAdminListResponse> response = new PageResponse<>(
+                List.of(
+                        new AuctionResultAdminListResponse(1L, 1L, 1L, 1L, 2L, BigDecimal.valueOf(10000), now),
+                        new AuctionResultAdminListResponse(2L, 2L, 3L, 2L, 4L, BigDecimal.valueOf(20000), now)
+                ), 0, 1, 2L, 20, true);
+
+        given(auctionResultAdminService.getAuctionResultList(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/auction-results"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("경매 결과 목록 조회 요청 성공"))
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("경매 결과 목록 조회 실패 - page 음수")
+    void getAuctionResultList_fail_pageIsNegative() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/admin/auction-results")
+                        .param("page", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지는 0 이상이어야 합니다"));
+    }
+
+    @Test
+    @DisplayName("경매 결과 목록 조회 실패 - size 0")
+    void getAuctionResultList_fail_sizeIsZero() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/admin/auction-results")
+                        .param("size", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지 크기는 1 이상이어야 합니다"));
+    }
+
+    @Test
+    @DisplayName("경매 결과 목록 조회 실패 - size 100 초과")
+    void getAuctionResultList_fail_sizeTooLarge() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/admin/auction-results")
+                        .param("size", "101"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지 크기는 100 이하여야 합니다"));
+    }
+}

--- a/src/test/java/com/example/auction/domain/auction/result/controller/AuctionResultAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/result/controller/AuctionResultAdminControllerTest.java
@@ -92,7 +92,7 @@ class AuctionResultAdminControllerTest {
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
-                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional()
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)").optional()
                         )
                 ));
     }

--- a/src/test/java/com/example/auction/domain/auction/result/service/AuctionResultAdminServiceTest.java
+++ b/src/test/java/com/example/auction/domain/auction/result/service/AuctionResultAdminServiceTest.java
@@ -1,0 +1,94 @@
+package com.example.auction.domain.auction.result.service;
+
+import com.example.auction.common.dto.PageResponse;
+import com.example.auction.domain.auction.result.dto.AuctionResultAdminListResponse;
+import com.example.auction.domain.auction.result.dto.AuctionResultAdminPageCondition;
+import com.example.auction.domain.auction.result.entity.AuctionResult;
+import com.example.auction.domain.auction.result.repository.AuctionResultRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuctionResultAdminServiceTest {
+
+    @InjectMocks
+    private AuctionResultAdminService auctionResultAdminService;
+
+    @Mock
+    private AuctionResultRepository auctionResultRepository;
+
+
+    // ========================
+    // 경매 결과 목록 조회
+    // ========================
+
+    @Test
+    @DisplayName("경매 결과 목록 조회 성공")
+    void getAuctionResultList_success() {
+        // given
+        AuctionResultAdminPageCondition condition = new AuctionResultAdminPageCondition();
+
+        AuctionResult result1 = AuctionResult.of(BigDecimal.valueOf(10000), 1L, 1L, 2L, 1L);
+        ReflectionTestUtils.setField(result1, "id", 1L);
+        ReflectionTestUtils.setField(result1, "createdAt", LocalDateTime.now());
+
+        AuctionResult result2 = AuctionResult.of(BigDecimal.valueOf(20000), 2L, 3L, 4L, 2L);
+        ReflectionTestUtils.setField(result2, "id", 2L);
+        ReflectionTestUtils.setField(result2, "createdAt", LocalDateTime.now());
+
+        Page<AuctionResult> page = new PageImpl<>(List.of(result1, result2), PageRequest.of(0, 20), 2);
+        given(auctionResultRepository.findAll(any(Pageable.class))).willReturn(page);
+
+        // when
+        PageResponse<AuctionResultAdminListResponse> response = auctionResultAdminService.getAuctionResultList(condition);
+
+        // then
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.totalPages()).isEqualTo(1);
+        assertThat(response.totalElements()).isEqualTo(2);
+        assertThat(response.currentPage()).isEqualTo(0);
+        assertThat(response.size()).isEqualTo(20);
+        assertThat(response.isLast()).isTrue();
+        assertThat(response.content().get(0).auctionId()).isEqualTo(1L);
+        assertThat(response.content().get(0).price()).isEqualByComparingTo(BigDecimal.valueOf(10000));
+        assertThat(response.content().get(1).auctionId()).isEqualTo(2L);
+        assertThat(response.content().get(1).price()).isEqualByComparingTo(BigDecimal.valueOf(20000));
+    }
+
+    @Test
+    @DisplayName("경매 결과 목록 조회 성공 - 빈 리스트")
+    void getAuctionResultList_success_empty() {
+        // given
+        AuctionResultAdminPageCondition condition = new AuctionResultAdminPageCondition();
+        Page<AuctionResult> page = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
+        given(auctionResultRepository.findAll(any(Pageable.class))).willReturn(page);
+
+        // when
+        PageResponse<AuctionResultAdminListResponse> response = auctionResultAdminService.getAuctionResultList(condition);
+
+        // then
+        assertThat(response.content()).hasSize(0);
+        assertThat(response.totalPages()).isEqualTo(0);
+        assertThat(response.totalElements()).isEqualTo(0);
+        assertThat(response.currentPage()).isEqualTo(0);
+        assertThat(response.size()).isEqualTo(20);
+        assertThat(response.isLast()).isTrue();
+    }
+}

--- a/src/test/java/com/example/auction/domain/auth/controller/AuthAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auth/controller/AuthAdminControllerTest.java
@@ -8,6 +8,7 @@ import com.example.auction.domain.user.enums.UserRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -19,12 +20,16 @@ import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({AuthAdminController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class AuthAdminControllerTest {
 
     @Autowired
@@ -58,7 +63,11 @@ class AuthAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("관리자 회원가입 요청 성공"))
                 .andExpect(jsonPath("$.data.email").value("admin@test.com"))
-                .andExpect(jsonPath("$.data.role").value("ADMIN"));
+                .andExpect(jsonPath("$.data.role").value("ADMIN"))
+                .andDo(document("auth-admin/signup",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test

--- a/src/test/java/com/example/auction/domain/auth/controller/AuthAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auth/controller/AuthAdminControllerTest.java
@@ -23,6 +23,8 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -66,7 +68,12 @@ class AuthAdminControllerTest {
                 .andExpect(jsonPath("$.data.role").value("ADMIN"))
                 .andDo(document("auth-admin/signup",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("이메일"),
+                                fieldWithPath("password").description("비밀번호 (8자 이상)"),
+                                fieldWithPath("adminSecretKey").description("관리자 인증 키")
+                        )
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auth/controller/AuthControllerTest.java
@@ -31,6 +31,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -194,7 +196,8 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.data.refreshToken").value("refreshToken"))
                 .andDo(document("auth/refresh-token",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Refresh-Token").description("리프레시 토큰"))
                 ));
     }
 
@@ -230,13 +233,15 @@ class AuthControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer accessToken")
                         .requestAttr("accessToken", "accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("로그아웃 요청 성공"))
                 .andDo(document("auth/logout",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
                 ));
 
         verify(authService).logout(eq(1L), eq("accessToken"));

--- a/src/test/java/com/example/auction/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auth/controller/AuthControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -30,12 +31,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({AuthController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class AuthControllerTest {
 
     @Autowired
@@ -72,7 +77,11 @@ class AuthControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.email").value("test@test.com"))
-                .andExpect(jsonPath("$.data.role").value("USER"));
+                .andExpect(jsonPath("$.data.role").value("USER"))
+                .andDo(document("auth/signup",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -126,7 +135,11 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.accessToken").value("accessToken"))
-                .andExpect(jsonPath("$.data.refreshToken").value("refreshToken"));
+                .andExpect(jsonPath("$.data.refreshToken").value("refreshToken"))
+                .andDo(document("auth/login",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -178,7 +191,11 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.accessToken").value("newAccessToken"))
-                .andExpect(jsonPath("$.data.refreshToken").value("refreshToken"));
+                .andExpect(jsonPath("$.data.refreshToken").value("refreshToken"))
+                .andDo(document("auth/refresh-token",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -216,7 +233,11 @@ class AuthControllerTest {
                         .requestAttr("accessToken", "accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("로그아웃 요청 성공"));
+                .andExpect(jsonPath("$.message").value("로그아웃 요청 성공"))
+                .andDo(document("auth/logout",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
 
         verify(authService).logout(eq(1L), eq("accessToken"));
     }

--- a/src/test/java/com/example/auction/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auth/controller/AuthControllerTest.java
@@ -36,6 +36,8 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -82,7 +84,11 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andDo(document("auth/signup",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("이메일"),
+                                fieldWithPath("password").description("비밀번호 (8자 이상)")
+                        )
                 ));
     }
 
@@ -140,7 +146,11 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.data.refreshToken").value("refreshToken"))
                 .andDo(document("auth/login",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("이메일"),
+                                fieldWithPath("password").description("비밀번호 (8자 이상)")
+                        )
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/bid/controller/BidAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidAdminControllerTest.java
@@ -27,9 +27,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -78,7 +81,10 @@ class BidAdminControllerTest {
         given(bidAdminService.getBidList(any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/admin/bids"))
+        mockMvc.perform(get("/api/admin/bids")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("입찰 목록 조회 요청 성공"))
@@ -86,7 +92,15 @@ class BidAdminControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(3))
                 .andDo(document("bid-admin/get-bid-list",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)").optional(),
+                                parameterWithName("status").description("입찰 상태 필터 (ACTIVE / CLOSED / CANCELLED)").optional(),
+                                parameterWithName("auctionId").description("경매 식별자 필터").optional(),
+                                parameterWithName("userId").description("사용자 식별자 필터").optional()
+                        )
                 ));
     }
 
@@ -135,13 +149,16 @@ class BidAdminControllerTest {
         doNothing().when(bidAdminService).forceCancel(1L);
 
         // when & then
-        mockMvc.perform(delete("/api/admin/bids/1"))
+        mockMvc.perform(delete("/api/admin/bids/{bidId}", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("입찰 강제 취소 요청 성공"))
                 .andDo(document("bid-admin/force-cancel",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        pathParameters(parameterWithName("bidId").description("입찰 식별자"))
                 ));
 
         verify(bidAdminService).forceCancel(1L);

--- a/src/test/java/com/example/auction/domain/bid/controller/BidAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidAdminControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -26,6 +27,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -33,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest({BidAdminController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class BidAdminControllerTest {
 
     @Autowired
@@ -66,8 +71,9 @@ class BidAdminControllerTest {
         PageResponse<BidAdminListResponse> response = new PageResponse<>(
                 List.of(
                         new BidAdminListResponse(1L, 10L, 1L, BigDecimal.valueOf(1000), BidAuctionStatus.ACTIVE, now),
-                        new BidAdminListResponse(2L, 10L, 2L, BigDecimal.valueOf(900), BidAuctionStatus.CLOSED, now)
-                ), 0, 1, 2L, 20, true);
+                        new BidAdminListResponse(2L, 10L, 2L, BigDecimal.valueOf(900), BidAuctionStatus.CLOSED, now),
+                        new BidAdminListResponse(3L, 10L, 3L, BigDecimal.valueOf(800), BidAuctionStatus.CANCELLED, now)
+                ), 0, 1, 3L, 20, true);
 
         given(bidAdminService.getBidList(any())).willReturn(response);
 
@@ -76,8 +82,12 @@ class BidAdminControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("입찰 목록 조회 요청 성공"))
-                .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.content.length()").value(3))
+                .andExpect(jsonPath("$.data.totalElements").value(3))
+                .andDo(document("bid-admin/get-bid-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -128,7 +138,11 @@ class BidAdminControllerTest {
         mockMvc.perform(delete("/api/admin/bids/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("입찰 강제 취소 요청 성공"));
+                .andExpect(jsonPath("$.message").value("입찰 강제 취소 요청 성공"))
+                .andDo(document("bid-admin/force-cancel",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
 
         verify(bidAdminService).forceCancel(1L);
     }

--- a/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -29,13 +30,17 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({BidController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class BidControllerTest {
 
     @Autowired
@@ -80,7 +85,11 @@ class BidControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("입찰이 완료되었습니다"));
+                .andExpect(jsonPath("$.message").value("입찰이 완료되었습니다"))
+                .andDo(document("bid/place-bid",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -167,7 +176,11 @@ class BidControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("입찰 내역 조회가 완료되었습니다"))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andDo(document("bid/get-bids",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -212,7 +225,11 @@ class BidControllerTest {
         mockMvc.perform(get("/api/auctions/1/bids/winner/v1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("입찰 결과 조회가 완료되었습니다"));
+                .andExpect(jsonPath("$.message").value("입찰 결과 조회가 완료되었습니다"))
+                .andDo(document("bid/get-winner-bid",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
 
@@ -229,6 +246,10 @@ class BidControllerTest {
         mockMvc.perform(get("/api/auctions/1/bids/current/v1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("현재 최저가 입찰 조회가 완료되었습니다"));
+                .andExpect(jsonPath("$.message").value("현재 최저가 입찰 조회가 완료되었습니다"))
+                .andDo(document("bid/get-current-min-bid",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 }

--- a/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
@@ -6,6 +6,8 @@ import com.example.auction.common.exception.GlobalExceptionHandler;
 import com.example.auction.domain.bid.dto.request.BidRequest;
 import com.example.auction.domain.bid.dto.response.BidListResponse;
 import com.example.auction.domain.bid.dto.response.BidResponse;
+import com.example.auction.domain.bid.entity.Bid;
+import com.example.auction.domain.bid.enums.BidAuctionStatus;
 import com.example.auction.domain.bid.service.BidCommandFacade;
 import com.example.auction.domain.bid.service.BidQueryService;
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +32,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -82,7 +85,17 @@ class BidControllerTest {
     void placeBid_success() throws Exception {
         // given
         BidRequest request = new BidRequest(BigDecimal.valueOf(5000), "열심히 입찰합니다");
-        given(commandService.placeBidDis(any(), eq(1L), any())).willReturn(new BidResponse());
+
+        Bid bid = mock(Bid.class);
+        given(bid.getId()).willReturn(1L);
+        given(bid.getAuctionId()).willReturn(1L);
+        given(bid.getPrice()).willReturn(BigDecimal.valueOf(5000));
+        given(bid.getDescription()).willReturn("열심히 입찰합니다");
+        given(bid.getCreatedAt()).willReturn(LocalDateTime.now());
+        given(bid.getStatus()).willReturn(BidAuctionStatus.ACTIVE);
+        BidResponse response = BidResponse.of(bid);
+
+        given(commandService.placeBidDis(any(), eq(1L), any())).willReturn(response);
 
         // when & then
         mockMvc.perform(post("/api/auctions/{auctionId}/bids/v2", 1L)
@@ -241,7 +254,16 @@ class BidControllerTest {
     @DisplayName("입찰 결과 조회 성공")
     void getWinnerBid_success() throws Exception {
         // given
-        given(queryService.getWinnerBid(any(), eq(1L))).willReturn(new BidResponse());
+        Bid bid = mock(Bid.class);
+        given(bid.getId()).willReturn(1L);
+        given(bid.getAuctionId()).willReturn(1L);
+        given(bid.getPrice()).willReturn(BigDecimal.valueOf(5000));
+        given(bid.getDescription()).willReturn("열심히 입찰합니다");
+        given(bid.getCreatedAt()).willReturn(LocalDateTime.now());
+        given(bid.getStatus()).willReturn(BidAuctionStatus.ACTIVE);
+        BidResponse response = BidResponse.of(bid);
+
+        given(queryService.getWinnerBid(any(), eq(1L))).willReturn(response);
 
         // when & then
         mockMvc.perform(get("/api/auctions/{auctionId}/bids/winner/v1", 1L)
@@ -265,7 +287,16 @@ class BidControllerTest {
     @DisplayName("현재 최저가 입찰 조회 성공")
     void getCurrentMinBid_success() throws Exception {
         // given
-        given(queryService.getCurrentMinBid(any(), eq(1L))).willReturn(new BidResponse());
+        Bid bid = mock(Bid.class);
+        given(bid.getId()).willReturn(1L);
+        given(bid.getAuctionId()).willReturn(1L);
+        given(bid.getPrice()).willReturn(BigDecimal.valueOf(5000));
+        given(bid.getDescription()).willReturn("열심히 입찰합니다");
+        given(bid.getCreatedAt()).willReturn(LocalDateTime.now());
+        given(bid.getStatus()).willReturn(BidAuctionStatus.ACTIVE);
+        BidResponse response = BidResponse.of(bid);
+
+        given(queryService.getCurrentMinBid(any(), eq(1L))).willReturn(response);
 
         // when & then
         mockMvc.perform(get("/api/auctions/{auctionId}/bids/current/v1", 1L)

--- a/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
@@ -36,6 +36,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -94,7 +96,11 @@ class BidControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
-                        pathParameters(parameterWithName("auctionId").description("경매 식별자"))
+                        pathParameters(parameterWithName("auctionId").description("경매 식별자")),
+                        requestFields(
+                                fieldWithPath("price").description("입찰 금액 (0 초과 정수)"),
+                                fieldWithPath("description").description("입찰 설명 (1024자 이하)").optional()
+                        )
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
@@ -1,0 +1,234 @@
+package com.example.auction.domain.bid.controller;
+
+import com.example.auction.common.config.security.CustomUserDetails;
+import com.example.auction.common.dto.PageResponse;
+import com.example.auction.common.exception.GlobalExceptionHandler;
+import com.example.auction.domain.bid.dto.request.BidRequest;
+import com.example.auction.domain.bid.dto.response.BidListResponse;
+import com.example.auction.domain.bid.dto.response.BidResponse;
+import com.example.auction.domain.bid.service.BidCommandFacade;
+import com.example.auction.domain.bid.service.BidQueryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({BidController.class, GlobalExceptionHandler.class})
+@AutoConfigureMockMvc(addFilters = false)
+class BidControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private BidCommandFacade commandService;
+
+    @MockitoBean
+    private BidQueryService queryService;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        CustomUserDetails userDetails = new CustomUserDetails(1L, "USER");
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+
+    // ========================
+    // 입찰 생성 v2 (분산락)
+    // ========================
+
+    @Test
+    @DisplayName("입찰 생성 성공")
+    void placeBid_success() throws Exception {
+        // given
+        BidRequest request = new BidRequest(BigDecimal.valueOf(5000), "열심히 입찰합니다");
+        given(commandService.placeBidDis(any(), eq(1L), any())).willReturn(new BidResponse());
+
+        // when & then
+        mockMvc.perform(post("/api/auctions/1/bids/v2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("입찰이 완료되었습니다"));
+    }
+
+    @Test
+    @DisplayName("입찰 생성 실패 - 금액 null")
+    void placeBid_fail_priceNull() throws Exception {
+        // given
+        BidRequest request = new BidRequest(null, "입찰합니다");
+
+        // when & then
+        mockMvc.perform(post("/api/auctions/1/bids/v2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("입찰 금액은 필수입니다"));
+    }
+
+    @Test
+    @DisplayName("입찰 생성 실패 - 금액 0 이하")
+    void placeBid_fail_priceNotPositive() throws Exception {
+        // given
+        BidRequest request = new BidRequest(BigDecimal.ZERO, "입찰합니다");
+
+        // when & then
+        mockMvc.perform(post("/api/auctions/1/bids/v2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("입찰 금액은 0보다 커야 합니다"));
+    }
+
+    @Test
+    @DisplayName("입찰 생성 실패 - 금액 소수점 포함")
+    void placeBid_fail_priceHasFraction() throws Exception {
+        // given
+        BidRequest request = new BidRequest(BigDecimal.valueOf(5000.5), "입찰합니다");
+
+        // when & then
+        mockMvc.perform(post("/api/auctions/1/bids/v2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("입찰 금액은 정수여야 합니다"));
+    }
+
+    @Test
+    @DisplayName("입찰 생성 실패 - 설명 1024자 초과")
+    void placeBid_fail_descriptionTooLong() throws Exception {
+        // given
+        BidRequest request = new BidRequest(BigDecimal.valueOf(5000), "a".repeat(1025));
+
+        // when & then
+        mockMvc.perform(post("/api/auctions/1/bids/v2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("설명이 너무 깁니다"));
+    }
+
+
+    // ========================
+    // 특정 경매 입찰 조회
+    // ========================
+
+    @Test
+    @DisplayName("입찰 목록 조회 성공")
+    void getBids_success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PageResponse<BidListResponse> response = new PageResponse<>(
+                List.of(
+                        new BidListResponse(1L, 1L, BigDecimal.valueOf(3000), now),
+                        new BidListResponse(2L, 1L, BigDecimal.valueOf(4000), now)
+                ), 0, 1, 2L, 20, true);
+
+        given(queryService.getBids(any(), eq(1L), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/auctions/1/bids/v1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("입찰 내역 조회가 완료되었습니다"))
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("입찰 목록 조회 실패 - page 음수")
+    void getBids_fail_pageIsNegative() throws Exception {
+        mockMvc.perform(get("/api/auctions/1/bids/v1").param("page", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지는 0 이상이어야 합니다"));
+    }
+
+    @Test
+    @DisplayName("입찰 목록 조회 실패 - size 0")
+    void getBids_fail_sizeIsZero() throws Exception {
+        mockMvc.perform(get("/api/auctions/1/bids/v1").param("size", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지 크기는 1 이상이어야 합니다"));
+    }
+
+    @Test
+    @DisplayName("입찰 목록 조회 실패 - size 100 초과")
+    void getBids_fail_sizeTooLarge() throws Exception {
+        mockMvc.perform(get("/api/auctions/1/bids/v1").param("size", "101"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("페이지 크기는 100 이하여야 합니다"));
+    }
+
+
+    // ========================
+    // 입찰 결과 조회 (낙찰)
+    // ========================
+
+    @Test
+    @DisplayName("입찰 결과 조회 성공")
+    void getWinnerBid_success() throws Exception {
+        // given
+        given(queryService.getWinnerBid(any(), eq(1L))).willReturn(new BidResponse());
+
+        // when & then
+        mockMvc.perform(get("/api/auctions/1/bids/winner/v1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("입찰 결과 조회가 완료되었습니다"));
+    }
+
+
+    // ========================
+    // 현재 최저가 입찰 조회
+    // ========================
+    @Test
+    @DisplayName("현재 최저가 입찰 조회 성공")
+    void getCurrentMinBid_success() throws Exception {
+        // given
+        given(queryService.getCurrentMinBid(any(), eq(1L))).willReturn(new BidResponse());
+
+        // when & then
+        mockMvc.perform(get("/api/auctions/1/bids/current/v1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("현재 최저가 입찰 조회가 완료되었습니다"));
+    }
+}

--- a/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
@@ -212,7 +212,7 @@ class BidControllerTest {
                         pathParameters(parameterWithName("auctionId").description("경매 식별자")),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
-                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional()
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)").optional()
                         )
 
                 ));

--- a/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidControllerTest.java
@@ -30,10 +30,13 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -80,7 +83,8 @@ class BidControllerTest {
         given(commandService.placeBidDis(any(), eq(1L), any())).willReturn(new BidResponse());
 
         // when & then
-        mockMvc.perform(post("/api/auctions/1/bids/v2")
+        mockMvc.perform(post("/api/auctions/{auctionId}/bids/v2", 1L)
+                        .header("Authorization", "Bearer accessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -88,7 +92,9 @@ class BidControllerTest {
                 .andExpect(jsonPath("$.message").value("입찰이 완료되었습니다"))
                 .andDo(document("bid/place-bid",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("auctionId").description("경매 식별자"))
                 ));
     }
 
@@ -171,7 +177,10 @@ class BidControllerTest {
         given(queryService.getBids(any(), eq(1L), any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/auctions/1/bids/v1"))
+        mockMvc.perform(get("/api/auctions/{auctionId}/bids/v1", 1L)
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("입찰 내역 조회가 완료되었습니다"))
@@ -179,7 +188,14 @@ class BidControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andDo(document("bid/get-bids",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("auctionId").description("경매 식별자")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional()
+                        )
+
                 ));
     }
 
@@ -222,13 +238,16 @@ class BidControllerTest {
         given(queryService.getWinnerBid(any(), eq(1L))).willReturn(new BidResponse());
 
         // when & then
-        mockMvc.perform(get("/api/auctions/1/bids/winner/v1"))
+        mockMvc.perform(get("/api/auctions/{auctionId}/bids/winner/v1", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("입찰 결과 조회가 완료되었습니다"))
                 .andDo(document("bid/get-winner-bid",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("auctionId").description("경매 식별자"))
                 ));
     }
 
@@ -243,13 +262,16 @@ class BidControllerTest {
         given(queryService.getCurrentMinBid(any(), eq(1L))).willReturn(new BidResponse());
 
         // when & then
-        mockMvc.perform(get("/api/auctions/1/bids/current/v1"))
+        mockMvc.perform(get("/api/auctions/{auctionId}/bids/current/v1", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("현재 최저가 입찰 조회가 완료되었습니다"))
                 .andDo(document("bid/get-current-min-bid",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("auctionId").description("경매 식별자"))
                 ));
     }
 }

--- a/src/test/java/com/example/auction/domain/bid/controller/BidUserControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidUserControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -23,12 +24,16 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({BidUserController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class BidUserControllerTest {
 
     @Autowired
@@ -73,7 +78,11 @@ class BidUserControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("내 입찰 조회가 완료되었습니다."))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andDo(document("bid-user/get-my-bids",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));;
     }
 
     @Test

--- a/src/test/java/com/example/auction/domain/bid/controller/BidUserControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidUserControllerTest.java
@@ -24,9 +24,13 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -73,7 +77,10 @@ class BidUserControllerTest {
         given(queryService.getMyBids(any(), any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/me/bids"))
+        mockMvc.perform(get("/api/me/bids")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("내 입찰 조회가 완료되었습니다."))
@@ -81,7 +88,12 @@ class BidUserControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andDo(document("bid-user/get-my-bids",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional()
+                        )
                 ));;
     }
 

--- a/src/test/java/com/example/auction/domain/bid/controller/BidUserControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidUserControllerTest.java
@@ -92,7 +92,7 @@ class BidUserControllerTest {
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
-                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional()
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)").optional()
                         )
                 ));;
     }

--- a/src/test/java/com/example/auction/domain/bid/controller/BidUserControllerTest.java
+++ b/src/test/java/com/example/auction/domain/bid/controller/BidUserControllerTest.java
@@ -1,0 +1,95 @@
+package com.example.auction.domain.bid.controller;
+
+import com.example.auction.common.config.security.CustomUserDetails;
+import com.example.auction.common.dto.PageResponse;
+import com.example.auction.common.exception.GlobalExceptionHandler;
+import com.example.auction.domain.bid.dto.response.BidListResponse;
+import com.example.auction.domain.bid.service.BidQueryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({BidUserController.class, GlobalExceptionHandler.class})
+@AutoConfigureMockMvc(addFilters = false)
+class BidUserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BidQueryService queryService;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        CustomUserDetails userDetails = new CustomUserDetails(1L, "USER");
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+
+    // ========================
+    // 내 입찰 조회
+    // ========================
+
+    @Test
+    @DisplayName("내 입찰 조회 성공")
+    void getMyBids_success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PageResponse<BidListResponse> response = new PageResponse<>(
+                List.of(
+                        new BidListResponse(1L, 10L, BigDecimal.valueOf(3000), now),
+                        new BidListResponse(2L, 11L, BigDecimal.valueOf(5000), now)
+                ), 0, 1, 2L, 20, true);
+
+        given(queryService.getMyBids(any(), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/me/bids"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("내 입찰 조회가 완료되었습니다."))
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("내 입찰 조회 성공 - 빈 목록")
+    void getMyBids_success_empty() throws Exception {
+        // given
+        PageResponse<BidListResponse> response = new PageResponse<>(
+                List.of(), 0, 0, 0L, 20, true);
+
+        given(queryService.getMyBids(any(), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/me/bids"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content.length()").value(0))
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+    }
+}

--- a/src/test/java/com/example/auction/domain/category/controller/CategoryAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/category/controller/CategoryAdminControllerTest.java
@@ -6,6 +6,7 @@ import com.example.auction.domain.category.service.CategoryAdminService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -18,6 +19,9 @@ import java.time.LocalDateTime;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -25,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest({CategoryAdminController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 public class CategoryAdminControllerTest {
 
     @Autowired
@@ -58,7 +63,11 @@ public class CategoryAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("카테고리 생성 요청 성공"))
                 .andExpect(jsonPath("$.data.categoryId").value(1L))
-                .andExpect(jsonPath("$.data.name").value("전자기기"));
+                .andExpect(jsonPath("$.data.name").value("전자기기"))
+                .andDo(document("category-admin/create-category",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -113,7 +122,11 @@ public class CategoryAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("카테고리 이름 수정 요청 성공"))
                 .andExpect(jsonPath("$.data.categoryId").value(1L))
-                .andExpect(jsonPath("$.data.name").value("가전제품"));
+                .andExpect(jsonPath("$.data.name").value("가전제품"))
+                .andDo(document("category-admin/rename-category",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -153,7 +166,11 @@ public class CategoryAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("카테고리 이동 요청 성공"))
                 .andExpect(jsonPath("$.data.categoryId").value(1L))
-                .andExpect(jsonPath("$.data.parentId").value(2L));
+                .andExpect(jsonPath("$.data.parentId").value(2L))
+                .andDo(document("category-admin/move-category",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test

--- a/src/test/java/com/example/auction/domain/category/controller/CategoryAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/category/controller/CategoryAdminControllerTest.java
@@ -24,6 +24,8 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -72,7 +74,11 @@ public class CategoryAdminControllerTest {
                 .andDo(document("category-admin/create-category",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)"))
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        requestFields(
+                                fieldWithPath("parentId").description("부모 카테고리 식별자 (1 이상)").optional(),
+                                fieldWithPath("name").description("카테고리 이름")
+                        )
                 ));
     }
 
@@ -134,7 +140,8 @@ public class CategoryAdminControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
-                        pathParameters(parameterWithName("categoryId").description("카테고리 식별자"))
+                        pathParameters(parameterWithName("categoryId").description("카테고리 식별자")),
+                        requestFields(fieldWithPath("name").description("변경할 카테고리 이름"))
                 ));
     }
 
@@ -181,7 +188,8 @@ public class CategoryAdminControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
-                        pathParameters(parameterWithName("categoryId").description("카테고리 식별자"))
+                        pathParameters(parameterWithName("categoryId").description("카테고리 식별자")),
+                        requestFields(fieldWithPath("parentId").description("이동할 부모 카테고리 식별자 (1 이상)"))
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/category/controller/CategoryAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/category/controller/CategoryAdminControllerTest.java
@@ -19,9 +19,13 @@ import java.time.LocalDateTime;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -57,6 +61,7 @@ public class CategoryAdminControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/admin/categories")
+                        .header("Authorization", "Bearer accessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -66,7 +71,8 @@ public class CategoryAdminControllerTest {
                 .andExpect(jsonPath("$.data.name").value("전자기기"))
                 .andDo(document("category-admin/create-category",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)"))
                 ));
     }
 
@@ -115,7 +121,8 @@ public class CategoryAdminControllerTest {
         given(categoryAdminService.renameCategory(eq(1L), any(CategoryRenameRequest.class))).willReturn(response);
 
         // when & then
-        mockMvc.perform(patch("/api/admin/categories/1/name")
+        mockMvc.perform(patch("/api/admin/categories/{categoryId}/name", 1L)
+                        .header("Authorization", "Bearer accessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -125,7 +132,9 @@ public class CategoryAdminControllerTest {
                 .andExpect(jsonPath("$.data.name").value("가전제품"))
                 .andDo(document("category-admin/rename-category",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        pathParameters(parameterWithName("categoryId").description("카테고리 식별자"))
                 ));
     }
 
@@ -159,7 +168,8 @@ public class CategoryAdminControllerTest {
         given(categoryAdminService.moveCategory(eq(1L), any(CategoryMoveRequest.class))).willReturn(response);
 
         // when & then
-        mockMvc.perform(patch("/api/admin/categories/1/parent")
+        mockMvc.perform(patch("/api/admin/categories/{categoryId}/parent", 1L)
+                        .header("Authorization", "Bearer accessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -169,7 +179,9 @@ public class CategoryAdminControllerTest {
                 .andExpect(jsonPath("$.data.parentId").value(2L))
                 .andDo(document("category-admin/move-category",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        pathParameters(parameterWithName("categoryId").description("카테고리 식별자"))
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/example/auction/domain/category/controller/CategoryControllerTest.java
@@ -6,6 +6,7 @@ import com.example.auction.domain.category.service.CategoryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -15,12 +16,16 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({CategoryController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class CategoryControllerTest {
 
     @Autowired
@@ -54,7 +59,11 @@ class CategoryControllerTest {
                 .andExpect(jsonPath("$.message").value("카테고리 목록 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.length()").value(1))
                 .andExpect(jsonPath("$.data[0].name").value("전자기기"))
-                .andExpect(jsonPath("$.data[0].children[0].name").value("스마트폰"));
+                .andExpect(jsonPath("$.data[0].children[0].name").value("스마트폰"))
+                .andDo(document("category/get-category-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test

--- a/src/test/java/com/example/auction/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/example/auction/domain/category/controller/CategoryControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 
@@ -30,9 +29,6 @@ class CategoryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockitoBean
     private CategoryService categoryService;

--- a/src/test/java/com/example/auction/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/auction/domain/chat/controller/ChatControllerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -33,12 +34,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({ChatController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class ChatControllerTest {
 
     @Autowired
@@ -91,7 +96,11 @@ class ChatControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("채팅방을 생성했습니다"))
-                .andExpect(jsonPath("$.data.id").value(10L));
+                .andExpect(jsonPath("$.data.id").value(10L))
+                .andDo(document("chat/create-room",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
 
@@ -116,7 +125,11 @@ class ChatControllerTest {
                 .andExpect(jsonPath("$.message").value("채팅방 목록을 조회했습니다"))
                 .andExpect(jsonPath("$.data.length()").value(2))
                 .andExpect(jsonPath("$.data[0].id").value(1L))
-                .andExpect(jsonPath("$.data[1].id").value(2L));
+                .andExpect(jsonPath("$.data[1].id").value(2L))
+                .andDo(document("chat/get-rooms",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -132,6 +145,10 @@ class ChatControllerTest {
                 .andExpect(jsonPath("$.data.length()").value(0));
     }
 
+
+    // ========================
+    // 채팅방 제목 수정
+    // ========================
 
     @Test
     @DisplayName("채팅방 제목 수정 성공")
@@ -149,7 +166,11 @@ class ChatControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("채팅방 제목을 수정했습니다"))
                 .andExpect(jsonPath("$.data.id").value(10L))
-                .andExpect(jsonPath("$.data.title").value("새제목"));
+                .andExpect(jsonPath("$.data.title").value("새제목"))
+                .andDo(document("chat/update-room",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -197,7 +218,11 @@ class ChatControllerTest {
         mockMvc.perform(delete("/api/chat/rooms/10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("채팅방을 삭제했습니다"));
+                .andExpect(jsonPath("$.message").value("채팅방을 삭제했습니다"))
+                .andDo(document("chat/delete-room",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
 
         verify(chatService).deleteRoom(10L, 1L);
     }
@@ -224,7 +249,11 @@ class ChatControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("메시지 목록을 조회했습니다"))
                 .andExpect(jsonPath("$.data.messages.length()").value(2))
-                .andExpect(jsonPath("$.data.nextCursor").value((Object) null));
+                .andExpect(jsonPath("$.data.nextCursor").value((Object) null))
+                .andDo(document("chat/get-messages",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test

--- a/src/test/java/com/example/auction/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/auction/domain/chat/controller/ChatControllerTest.java
@@ -8,6 +8,7 @@ import com.example.auction.common.exception.GlobalExceptionHandler;
 import com.example.auction.domain.chat.dto.ChatMessageListResponse;
 import com.example.auction.domain.chat.dto.ChatMessageResponse;
 import com.example.auction.domain.chat.dto.ChatRoomResponse;
+import com.example.auction.domain.chat.dto.ChatRoomUpdateRequest;
 import com.example.auction.domain.chat.entity.MessageRole;
 import com.example.auction.domain.chat.service.ChatService;
 import org.junit.jupiter.api.AfterEach;
@@ -18,15 +19,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -41,6 +43,9 @@ class ChatControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private ChatService chatService;
@@ -125,6 +130,56 @@ class ChatControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+
+    @Test
+    @DisplayName("채팅방 제목 수정 성공")
+    void updateRoom_success() throws Exception {
+        // given
+        ChatRoomUpdateRequest request = new ChatRoomUpdateRequest("새제목");
+        ChatRoomResponse response = new ChatRoomResponse(10L, "새제목", LocalDateTime.now());
+        given(chatService.updateTitle(eq(10L), eq(1L), eq("새제목"))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(patch("/api/chat/rooms/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("채팅방 제목을 수정했습니다"))
+                .andExpect(jsonPath("$.data.id").value(10L))
+                .andExpect(jsonPath("$.data.title").value("새제목"));
+    }
+
+    @Test
+    @DisplayName("채팅방 제목 수정 실패 - 제목 공백")
+    void updateRoom_fail_titleBlank() throws Exception {
+        // given
+        ChatRoomUpdateRequest request = new ChatRoomUpdateRequest("");
+
+        // when & then
+        mockMvc.perform(patch("/api/chat/rooms/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("제목을 입력해 주세요"));
+    }
+
+    @Test
+    @DisplayName("채팅방 제목 수정 실패 - 제목 10자 초과")
+    void updateRoom_fail_titleTooLong() throws Exception {
+        // given
+        ChatRoomUpdateRequest request = new ChatRoomUpdateRequest("12345678901");
+
+        // when & then
+        mockMvc.perform(patch("/api/chat/rooms/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("제목은 10자 이하로 입력해 주세요"));
     }
 
 

--- a/src/test/java/com/example/auction/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/auction/domain/chat/controller/ChatControllerTest.java
@@ -34,9 +34,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -92,14 +97,16 @@ class ChatControllerTest {
         given(chatService.createRoom(1L)).willReturn(response);
 
         // when & then
-        mockMvc.perform(post("/api/chat/rooms"))
+        mockMvc.perform(post("/api/chat/rooms")
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("채팅방을 생성했습니다"))
                 .andExpect(jsonPath("$.data.id").value(10L))
                 .andDo(document("chat/create-room",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
                 ));
     }
 
@@ -119,7 +126,8 @@ class ChatControllerTest {
         given(chatService.getRooms(1L)).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/chat/rooms"))
+        mockMvc.perform(get("/api/chat/rooms")
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("채팅방 목록을 조회했습니다"))
@@ -128,7 +136,8 @@ class ChatControllerTest {
                 .andExpect(jsonPath("$.data[1].id").value(2L))
                 .andDo(document("chat/get-rooms",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
                 ));
     }
 
@@ -159,7 +168,8 @@ class ChatControllerTest {
         given(chatService.updateTitle(eq(10L), eq(1L), eq("새제목"))).willReturn(response);
 
         // when & then
-        mockMvc.perform(patch("/api/chat/rooms/10")
+        mockMvc.perform(patch("/api/chat/rooms/{roomId}", 10L)
+                        .header("Authorization", "Bearer accessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -169,7 +179,10 @@ class ChatControllerTest {
                 .andExpect(jsonPath("$.data.title").value("새제목"))
                 .andDo(document("chat/update-room",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("roomId").description("채팅방 식별자")),
+                        requestFields(fieldWithPath("title").description("변경할 채팅방 제목 (10자 이하)"))
                 ));
     }
 
@@ -215,13 +228,16 @@ class ChatControllerTest {
         doNothing().when(chatService).deleteRoom(10L, 1L);
 
         // when & then
-        mockMvc.perform(delete("/api/chat/rooms/10"))
+        mockMvc.perform(delete("/api/chat/rooms/{roomId}", 10L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("채팅방을 삭제했습니다"))
                 .andDo(document("chat/delete-room",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("roomId").description("채팅방 식별자"))
                 ));
 
         verify(chatService).deleteRoom(10L, 1L);
@@ -244,7 +260,8 @@ class ChatControllerTest {
         given(chatService.getMessages(eq(10L), eq(1L), eq(null), eq(20))).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/chat/rooms/10/messages"))
+        mockMvc.perform(get("/api/chat/rooms/{roomId}/messages", 10L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("메시지 목록을 조회했습니다"))
@@ -252,7 +269,13 @@ class ChatControllerTest {
                 .andExpect(jsonPath("$.data.nextCursor").value((Object) null))
                 .andDo(document("chat/get-messages",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("roomId").description("채팅방 식별자")),
+                        queryParameters(
+                                parameterWithName("cursor").description("이전 페이지의 마지막 메시지 식별자").optional(),
+                                parameterWithName("size").description("조회 개수 (기본값 20)").optional()
+                        )
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewAdminControllerTest.java
@@ -93,7 +93,7 @@ class ReviewAdminControllerTest {
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
-                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional(),
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)").optional(),
                                 parameterWithName("auctionId").description("경매 식별자 필터").optional(),
                                 parameterWithName("reviewerId").description("작성자 식별자 필터").optional(),
                                 parameterWithName("revieweeId").description("대상자 식별자 필터").optional(),

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewAdminControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,6 +25,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -31,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest({ReviewAdminController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class ReviewAdminControllerTest {
 
     @Autowired
@@ -75,7 +80,11 @@ class ReviewAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 목록 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andDo(document("review-admin/get-review-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -126,7 +135,11 @@ class ReviewAdminControllerTest {
         mockMvc.perform(delete("/api/admin/reviews/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("리뷰 강제 삭제 요청 성공"));
+                .andExpect(jsonPath("$.message").value("리뷰 강제 삭제 요청 성공"))
+                .andDo(document("review-admin/force-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
 
         verify(reviewAdminService).forceDelete(1L);
     }

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewAdminControllerTest.java
@@ -25,9 +25,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -75,7 +78,10 @@ class ReviewAdminControllerTest {
         given(reviewAdminService.getReviewList(any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/admin/reviews"))
+        mockMvc.perform(get("/api/admin/reviews")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 목록 조회 요청 성공"))
@@ -83,7 +89,16 @@ class ReviewAdminControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andDo(document("review-admin/get-review-list",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional(),
+                                parameterWithName("auctionId").description("경매 식별자 필터").optional(),
+                                parameterWithName("reviewerId").description("작성자 식별자 필터").optional(),
+                                parameterWithName("revieweeId").description("대상자 식별자 필터").optional(),
+                                parameterWithName("score").description("별점 필터").optional()
+                        )
                 ));
     }
 
@@ -132,13 +147,16 @@ class ReviewAdminControllerTest {
         doNothing().when(reviewAdminService).forceDelete(1L);
 
         // when & then
-        mockMvc.perform(delete("/api/admin/reviews/1"))
+        mockMvc.perform(delete("/api/admin/reviews/{reviewId}", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 강제 삭제 요청 성공"))
                 .andDo(document("review-admin/force-delete",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        pathParameters(parameterWithName("reviewId").description("리뷰 식별자"))
                 ));
 
         verify(reviewAdminService).forceDelete(1L);

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
@@ -70,6 +70,40 @@ class ReviewControllerTest {
         SecurityContextHolder.clearContext();
     }
 
+
+    // ========================
+    // 리뷰 이미지 Presigned URL 발급
+    // ========================
+
+    @Test
+    @DisplayName("Presigned URL 발급 성공")
+    void getPresignedUrl_success() throws Exception {
+        // given
+        ReviewImagePresignResponse response = new ReviewImagePresignResponse(
+                "https://s3.amazonaws.com/bucket/reviews/1/uuid.jpg?presigned=...",
+                "https://cdn.example.com/reviews/1/uuid.jpg"
+        );
+
+        given(reviewImageService.generatePresignedUrl(eq(1L), eq("image/jpeg"))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/reviews/image/presigned-url")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("contentType", "image/jpeg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("이미지 업로드 URL 발급 성공"))
+                .andExpect(jsonPath("$.data.presignedUrl").exists())
+                .andExpect(jsonPath("$.data.imageUrl").exists())
+                .andDo(document("review/get-presigned-url",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        queryParameters(parameterWithName("contentType").description("이미지 MIME 타입 (image/jpeg, image/png, image/webp)").optional())
+                ));
+    }
+
+
     // ========================
     // 리뷰 생성
     // ========================
@@ -78,8 +112,8 @@ class ReviewControllerTest {
     @DisplayName("리뷰 생성 성공")
     void createReview_success() throws Exception {
         // given
-        ReviewCreateRequest request = new ReviewCreateRequest(10L, 5, "좋아요", null);
-        ReviewCreateResponse response = new ReviewCreateResponse(1L, 10L, 1L, 2L, 5, "좋아요", null, LocalDateTime.now());
+        ReviewCreateRequest request = new ReviewCreateRequest(10L, 5, "좋아요", "https://cdn.example.com/image.jpg");
+        ReviewCreateResponse response = new ReviewCreateResponse(1L, 10L, 1L, 2L, 5, "좋아요", "https://cdn.example.com/image.jpg", LocalDateTime.now());
 
         given(reviewService.createReview(eq(1L), any(ReviewCreateRequest.class))).willReturn(response);
 
@@ -100,7 +134,8 @@ class ReviewControllerTest {
                         requestFields(
                                 fieldWithPath("auctionId").description("경매 식별자"),
                                 fieldWithPath("score").description("별점 (1 ~ 5)"),
-                                fieldWithPath("description").description("리뷰 내용 (500자 이하)").optional()
+                                fieldWithPath("description").description("리뷰 내용 (500자 이하)").optional(),
+                                fieldWithPath("imageUrl").description("리뷰 이미지 URL").optional()
                         )
                 ));
     }
@@ -372,8 +407,8 @@ class ReviewControllerTest {
     @DisplayName("리뷰 수정 성공")
     void modifyReview_success() throws Exception {
         // given
-        ReviewModifyRequest request = new ReviewModifyRequest(1, "별로에요", null);
-        ReviewModifyResponse response = new ReviewModifyResponse(1L, 1, "별로에요", null, LocalDateTime.now(), LocalDateTime.now());
+        ReviewModifyRequest request = new ReviewModifyRequest(1, "별로에요", "https://cdn.example.com/image.jpg");
+        ReviewModifyResponse response = new ReviewModifyResponse(1L, 1, "별로에요", "https://cdn.example.com/image.jpg", LocalDateTime.now(), LocalDateTime.now());
 
         given(reviewService.modifyReview(eq(1L), eq(1L), any(ReviewModifyRequest.class))).willReturn(response);
 
@@ -394,7 +429,8 @@ class ReviewControllerTest {
                         pathParameters(parameterWithName("reviewId").description("리뷰 식별자")),
                         requestFields(
                                 fieldWithPath("score").description("별점 (1 ~ 5)").optional(),
-                                fieldWithPath("description").description("리뷰 내용 (500자 이하)").optional()
+                                fieldWithPath("description").description("리뷰 내용 (500자 이하)").optional(),
+                                fieldWithPath("imageUrl").description("리뷰 이미지 URL").optional()
                         )
                 ));
     }

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
@@ -127,6 +127,7 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.message").value("리뷰 생성 요청 성공"))
                 .andExpect(jsonPath("$.data.auctionId").value(10L))
                 .andExpect(jsonPath("$.data.score").value(5))
+                .andExpect(jsonPath("$.data.imageUrl").value("https://cdn.example.com/image.jpg"))
                 .andDo(document("review/create-review",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
@@ -233,7 +234,7 @@ class ReviewControllerTest {
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0 이상)"),
-                                parameterWithName("size").description("페이지 크기 (0 ~ 100)"),
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)"),
                                 parameterWithName("startDate").description("조회 시작일 (yyyy-MM-dd)").optional(),
                                 parameterWithName("endDate").description("조회 종료일 (yyyy-MM-dd)").optional()
                         )
@@ -318,7 +319,7 @@ class ReviewControllerTest {
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0 이상)"),
-                                parameterWithName("size").description("페이지 크기 (0 ~ 100)"),
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)"),
                                 parameterWithName("startDate").description("조회 시작일 (yyyy-MM-dd)").optional(),
                                 parameterWithName("endDate").description("조회 종료일 (yyyy-MM-dd)").optional()
                         )

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -28,12 +29,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({ReviewController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class ReviewControllerTest {
 
     @Autowired
@@ -81,7 +86,11 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 생성 요청 성공"))
                 .andExpect(jsonPath("$.data.auctionId").value(10L))
-                .andExpect(jsonPath("$.data.score").value(5));
+                .andExpect(jsonPath("$.data.score").value(5))
+                .andDo(document("review/create-review",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -130,7 +139,7 @@ class ReviewControllerTest {
     }
 
     @Test
-    @DisplayName("리뷰 작성 실패 - 설명 500자 초과")
+    @DisplayName("리뷰 생성 실패 - 설명 500자 초과")
     void createReview_fail_descriptionTooLong() throws Exception {
         // given
         ReviewCreateRequest request = new ReviewCreateRequest(1L, 5, "a".repeat(501), null);
@@ -167,7 +176,11 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("작성한 리뷰 목록 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andDo(document("review/get-written-review-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -238,7 +251,11 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("받은 리뷰 목록 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andDo(document("review/get-received-review-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -306,7 +323,11 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 상세 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.reviewId").value(1L))
-                .andExpect(jsonPath("$.data.score").value(5));
+                .andExpect(jsonPath("$.data.score").value(5))
+                .andDo(document("review/get-review",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
 
@@ -331,7 +352,11 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 수정 요청 성공"))
                 .andExpect(jsonPath("$.data.reviewId").value(1L))
-                .andExpect(jsonPath("$.data.score").value(1));
+                .andExpect(jsonPath("$.data.score").value(1))
+                .andDo(document("review/modify-review",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -394,7 +419,11 @@ class ReviewControllerTest {
         mockMvc.perform(delete("/api/reviews/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("리뷰 삭제 요청 성공"));
+                .andExpect(jsonPath("$.message").value("리뷰 삭제 요청 성공"))
+                .andDo(document("review/delete-review",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
 
         verify(reviewService).deleteReview(1L, 1L);
     }

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
@@ -34,6 +34,8 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -94,7 +96,12 @@ class ReviewControllerTest {
                 .andDo(document("review/create-review",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        requestFields(
+                                fieldWithPath("auctionId").description("경매 식별자"),
+                                fieldWithPath("score").description("별점 (1 ~ 5)"),
+                                fieldWithPath("description").description("리뷰 내용 (500자 이하)").optional()
+                        )
                 ));
     }
 
@@ -384,7 +391,11 @@ class ReviewControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
-                        pathParameters(parameterWithName("reviewId").description("리뷰 식별자"))
+                        pathParameters(parameterWithName("reviewId").description("리뷰 식별자")),
+                        requestFields(
+                                fieldWithPath("score").description("별점 (1 ~ 5)").optional(),
+                                fieldWithPath("description").description("리뷰 내용 (500자 이하)").optional()
+                        )
                 ));
     }
 

--- a/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/auction/domain/review/controller/ReviewControllerTest.java
@@ -29,9 +29,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -80,6 +83,7 @@ class ReviewControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/reviews")
+                        .header("Authorization", "Bearer accessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -89,7 +93,8 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.data.score").value(5))
                 .andDo(document("review/create-review",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
                 ));
     }
 
@@ -171,7 +176,10 @@ class ReviewControllerTest {
         given(reviewService.getWrittenReviewList(eq(1L), any(ReviewSearchCondition.class))).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/reviews/written"))
+        mockMvc.perform(get("/api/reviews/written")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("작성한 리뷰 목록 조회 요청 성공"))
@@ -179,7 +187,14 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andDo(document("review/get-written-review-list",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)"),
+                                parameterWithName("size").description("페이지 크기 (0 ~ 100)"),
+                                parameterWithName("startDate").description("조회 시작일 (yyyy-MM-dd)").optional(),
+                                parameterWithName("endDate").description("조회 종료일 (yyyy-MM-dd)").optional()
+                        )
                 ));
     }
 
@@ -246,7 +261,10 @@ class ReviewControllerTest {
         given(reviewService.getReceivedReviewList(eq(1L), any(ReviewSearchCondition.class))).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/reviews/received"))
+        mockMvc.perform(get("/api/reviews/received")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("받은 리뷰 목록 조회 요청 성공"))
@@ -254,7 +272,14 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andDo(document("review/get-received-review-list",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)"),
+                                parameterWithName("size").description("페이지 크기 (0 ~ 100)"),
+                                parameterWithName("startDate").description("조회 시작일 (yyyy-MM-dd)").optional(),
+                                parameterWithName("endDate").description("조회 종료일 (yyyy-MM-dd)").optional()
+                        )
                 ));
     }
 
@@ -318,7 +343,7 @@ class ReviewControllerTest {
         given(reviewService.getReview(1L)).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/reviews/1"))
+        mockMvc.perform(get("/api/reviews/{reviewId}", 1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 상세 조회 요청 성공"))
@@ -326,7 +351,8 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.data.score").value(5))
                 .andDo(document("review/get-review",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(parameterWithName("reviewId").description("리뷰 식별자"))
                 ));
     }
 
@@ -345,9 +371,10 @@ class ReviewControllerTest {
         given(reviewService.modifyReview(eq(1L), eq(1L), any(ReviewModifyRequest.class))).willReturn(response);
 
         // when & then
-        mockMvc.perform(patch("/api/reviews/1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(patch("/api/reviews/{reviewId}", 1L)
+                        .header("Authorization", "Bearer accessToken")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 수정 요청 성공"))
@@ -355,7 +382,9 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.data.score").value(1))
                 .andDo(document("review/modify-review",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("reviewId").description("리뷰 식별자"))
                 ));
     }
 
@@ -416,13 +445,16 @@ class ReviewControllerTest {
         doNothing().when(reviewService).deleteReview(1L, 1L);
 
         // when & then
-        mockMvc.perform(delete("/api/reviews/1"))
+        mockMvc.perform(delete("/api/reviews/{reviewId}", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("리뷰 삭제 요청 성공"))
                 .andDo(document("review/delete-review",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        pathParameters(parameterWithName("reviewId").description("리뷰 식별자"))
                 ));
 
         verify(reviewService).deleteReview(1L, 1L);

--- a/src/test/java/com/example/auction/domain/user/controller/UserAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/user/controller/UserAdminControllerTest.java
@@ -28,9 +28,12 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -61,11 +64,11 @@ class UserAdminControllerTest {
 
 
     // ========================
-    // 유저 목록 조회
+    // 사용자 목록 조회
     // ========================
 
     @Test
-    @DisplayName("유저 목록 조회 성공")
+    @DisplayName("사용자 목록 조회 성공")
     void getUserList_success() throws Exception {
         // given
         LocalDateTime now = LocalDateTime.now();
@@ -78,20 +81,31 @@ class UserAdminControllerTest {
         given(userAdminService.getUserList(any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/admin/users"))
+        mockMvc.perform(get("/api/admin/users")
+                        .header("Authorization", "Bearer accessToken")
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("유저 목록 조회 요청 성공"))
+                .andExpect(jsonPath("$.message").value("사용자 목록 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
                 .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andDo(document("user-admin/get-user-list",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
+                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional(),
+                                parameterWithName("deleted").description("탈퇴 여부 필터 (true / false)").optional(),
+                                parameterWithName("role").description("권한 필터 (USER / ADMIN)").optional(),
+                                parameterWithName("email").description("이메일 검색").optional()
+                        )
                 ));
     }
 
     @Test
-    @DisplayName("유저 목록 조회 실패 - page 음수")
+    @DisplayName("사용자 목록 조회 실패 - page 음수")
     void getUserList_fail_pageIsNegative() throws Exception {
         // when & then
         mockMvc.perform(get("/api/admin/users")
@@ -102,7 +116,7 @@ class UserAdminControllerTest {
     }
 
     @Test
-    @DisplayName("유저 목록 조회 실패 - size 0")
+    @DisplayName("사용자 목록 조회 실패 - size 0")
     void getUserList_fail_sizeIsZero() throws Exception {
         // when & then
         mockMvc.perform(get("/api/admin/users")
@@ -113,7 +127,7 @@ class UserAdminControllerTest {
     }
 
     @Test
-    @DisplayName("유저 목록 조회 실패 - size 100 초과")
+    @DisplayName("사용자 목록 조회 실패 - size 100 초과")
     void getUserList_fail_sizeTooLarge() throws Exception {
         // when & then
         mockMvc.perform(get("/api/admin/users")
@@ -125,11 +139,11 @@ class UserAdminControllerTest {
 
 
     // ========================
-    // 유저 상세 조회
+    // 사용자 상세 조회
     // ========================
 
     @Test
-    @DisplayName("유저 상세 조회 성공")
+    @DisplayName("사용자 상세 조회 성공")
     void getUserDetail_success() throws Exception {
         // given
         LocalDateTime now = LocalDateTime.now();
@@ -139,25 +153,28 @@ class UserAdminControllerTest {
         given(userAdminService.getUserDetail(eq(1L))).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/admin/users/1"))
+        mockMvc.perform(get("/api/admin/users/{userId}", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("유저 상세 조회 요청 성공"))
+                .andExpect(jsonPath("$.message").value("사용자 상세 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.userId").value(1))
                 .andExpect(jsonPath("$.data.email").value("user@test.com"))
                 .andDo(document("user-admin/get-user-detail",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        pathParameters(parameterWithName("userId").description("사용자 식별자"))
                 ));
     }
 
 
     // ========================
-    // 유저 강제 탈퇴
+    // 사용자 강제 탈퇴
     // ========================
 
     @Test
-    @DisplayName("유저 강제 탈퇴 성공")
+    @DisplayName("사용자 강제 탈퇴 성공")
     void forceWithdraw_success() throws Exception {
         // given
         LocalDateTime now = LocalDateTime.now();
@@ -167,15 +184,18 @@ class UserAdminControllerTest {
         given(userAdminService.forceWithdraw(eq(1L))).willReturn(response);
 
         // when & then
-        mockMvc.perform(delete("/api/admin/users/1"))
+        mockMvc.perform(delete("/api/admin/users/{userId}", 1L)
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("유저 강제 탈퇴 요청 성공"))
+                .andExpect(jsonPath("$.message").value("사용자 강제 탈퇴 요청 성공"))
                 .andExpect(jsonPath("$.data.email").value("user@test.com"))
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andDo(document("user-admin/force-withdraw",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
+                        pathParameters(parameterWithName("userId").description("사용자 식별자"))
                 ));
     }
 }

--- a/src/test/java/com/example/auction/domain/user/controller/UserAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/user/controller/UserAdminControllerTest.java
@@ -96,7 +96,7 @@ class UserAdminControllerTest {
                         requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰 (ADMIN)")),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0 이상)").optional(),
-                                parameterWithName("size").description("페이지 크기 (0 ~ 100)").optional(),
+                                parameterWithName("size").description("페이지 크기 (1 ~ 100)").optional(),
                                 parameterWithName("deleted").description("탈퇴 여부 필터 (true / false)").optional(),
                                 parameterWithName("role").description("권한 필터 (USER / ADMIN)").optional(),
                                 parameterWithName("email").description("이메일 검색").optional()

--- a/src/test/java/com/example/auction/domain/user/controller/UserAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/user/controller/UserAdminControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -27,6 +28,9 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -34,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest({UserAdminController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class UserAdminControllerTest {
 
     @Autowired
@@ -78,7 +83,11 @@ class UserAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("유저 목록 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andDo(document("user-admin/get-user-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -135,7 +144,11 @@ class UserAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("유저 상세 조회 요청 성공"))
                 .andExpect(jsonPath("$.data.userId").value(1))
-                .andExpect(jsonPath("$.data.email").value("user@test.com"));
+                .andExpect(jsonPath("$.data.email").value("user@test.com"))
+                .andDo(document("user-admin/get-user-detail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
 
@@ -159,6 +172,10 @@ class UserAdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("유저 강제 탈퇴 요청 성공"))
                 .andExpect(jsonPath("$.data.email").value("user@test.com"))
-                .andExpect(jsonPath("$.data.role").value("USER"));
+                .andExpect(jsonPath("$.data.role").value("USER"))
+                .andDo(document("user-admin/force-withdraw",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 }

--- a/src/test/java/com/example/auction/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/auction/domain/user/controller/UserControllerTest.java
@@ -30,6 +30,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -77,14 +79,16 @@ class UserControllerTest {
         given(userService.myPage(1L)).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/users"))
+        mockMvc.perform(get("/api/users")
+                        .header("Authorization", "Bearer accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.email").value("test@test.com"))
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andDo(document("user/my-page",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
                 ));
     }
 
@@ -103,6 +107,7 @@ class UserControllerTest {
 
         // when & then
         mockMvc.perform(patch("/api/users/password")
+                        .header("Authorization", "Bearer accessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -110,7 +115,8 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.message").value("비밀번호 변경 요청 성공"))
                 .andDo(document("user/change-password",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
                 ));
     }
 
@@ -161,6 +167,7 @@ class UserControllerTest {
 
         // when & then
         mockMvc.perform(delete("/api/users")
+                        .header("Authorization", "Bearer accessToken")
                         .requestAttr("accessToken", "accessToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -169,7 +176,8 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andDo(document("user/withdraw",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
                 ));
 
         verify(userService).withdraw(eq(1L), eq("accessToken"));

--- a/src/test/java/com/example/auction/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/auction/domain/user/controller/UserControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -29,12 +30,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({UserController.class, GlobalExceptionHandler.class})
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
 class UserControllerTest {
 
     @Autowired
@@ -76,7 +81,11 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.email").value("test@test.com"))
-                .andExpect(jsonPath("$.data.role").value("USER"));
+                .andExpect(jsonPath("$.data.role").value("USER"))
+                .andDo(document("user/my-page",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
 
@@ -98,7 +107,11 @@ class UserControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("비밀번호 변경 요청 성공"));
+                .andExpect(jsonPath("$.message").value("비밀번호 변경 요청 성공"))
+                .andDo(document("user/change-password",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
     }
 
     @Test
@@ -153,7 +166,11 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("탈퇴 요청 성공"))
                 .andExpect(jsonPath("$.data.email").value("test@test.com"))
-                .andExpect(jsonPath("$.data.role").value("USER"));
+                .andExpect(jsonPath("$.data.role").value("USER"))
+                .andDo(document("user/withdraw",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
 
         verify(userService).withdraw(eq(1L), eq("accessToken"));
     }

--- a/src/test/java/com/example/auction/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/auction/domain/user/controller/UserControllerTest.java
@@ -35,6 +35,8 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -116,7 +118,11 @@ class UserControllerTest {
                 .andDo(document("user/change-password",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰"))
+                        requestHeaders(headerWithName("Authorization").description("Bearer 액세스 토큰")),
+                        requestFields(
+                                fieldWithPath("oldPassword").description("기존 비밀번호"),
+                                fieldWithPath("newPassword").description("새 비밀번호 (8자 이상)")
+                        )
                 ));
     }
 


### PR DESCRIPTION
## 📝 작업 내용
### 설정
- Spring REST Docs 4.0.0 의존성 추가 및 `@AuthConfigureRestDocs` 설정
- `gitignore`에서 `docs/` 경로 제거 및 AsciiDoc 소스 파일 추가
- API 문서 페이지 (`/docs/**`) permitAll로 Security 설정 수정

### REST Docs 문서화 적용
| 컨트롤러 | 요청 헤더 | 경로 변수 | 쿼리 파라미터 | 요청 필드 |
|---|---|---|---|---|
| AuthController | ✅ | - | - | ✅ |
| AuthAdminController | ✅ | - | - | ✅ |
| UserController | ✅ | - | - | ✅ |
| UserAdminController | ✅ | - | - | - |
| AuctionController | ✅ | ✅ | - | ✅ |
| AuctionAdminController | ✅ | ✅ | - | - |
| AuctionResultAdminController | ✅ | - | - | - |
| BidController | ✅ | ✅ | ✅ | ✅ |
| BidUserController | ✅ | ✅ | - | - |
| BidAdminController | ✅ | - | - | - |
| CategoryAdminController | ✅ | ✅ | - | ✅ |
| ReviewController | ✅ | ✅ | ✅ | ✅ |
| ReviewAdminController | ✅ | ✅ | ✅ | - |
| ChatController | ✅ | ✅ | ✅ | ✅ |

### 버그 수정
- `BidControllerTest`: `BidResponse` 생성 시 모든 응답 필드가 null로 반환되던 문제 수정
  - `new BidResponse()` 대신 `mock(Bid.class)` + `BidResponse.of(bid)` 패턴으로 변경
- `ReviewControllerTest`: `imageUrl` 필드 미문서화로 인한 `SnippetException` 수정
  - `requestFields`에 `imageUrl` 항목 추가

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항
전체 컨트롤러 테스트 통과 후 `build/generated-snippets` 하위 스니펫 정상 생성 확인
`./gradlew test` 실행 후 `build/docs/asciidoc` 하위 html 파일 정상 생성 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 모든 API의 자동 생성 문서를 `/docs/**`에서 인증 없이 접근 가능하도록 제공
  * 경매, 입찰, 카테고리, 리뷰, 채팅, 인증, 사용자 API에 대한 완전한 Asciidoc 문서 추가

* **Bug Fixes**
  * 일부 API 응답 메시지의 용어 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->