### PR TITLE
[FIX] eventBridge/eventbridge 패키지 중복 충돌 해결 및 소문자로 통일

### DIFF
--- a/src/main/java/com/example/auction/domain/auction/eventbridge/AuctionCancelledEventBridge.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/AuctionCancelledEventBridge.java
@@ -1,5 +1,0 @@
-package com.example.auction.domain.auction.eventbridge;
-
-public record AuctionCancelledEventBridge (
-        Long auctionId
-) {}

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/controller/OutboxAdminController.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/controller/OutboxAdminController.java
@@ -1,8 +1,8 @@
-package com.example.auction.domain.auction.eventBridge.controller;
+package com.example.auction.domain.auction.eventbridge.controller;
 
 import com.example.auction.common.dto.BaseResponse;
-import com.example.auction.domain.auction.eventBridge.dto.OutboxAdminResponse;
-import com.example.auction.domain.auction.eventBridge.service.OutboxAdminService;
+import com.example.auction.domain.auction.eventbridge.dto.OutboxAdminResponse;
+import com.example.auction.domain.auction.eventbridge.service.OutboxAdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/dto/OutboxAdminResponse.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/dto/OutboxAdminResponse.java
@@ -1,6 +1,6 @@
-package com.example.auction.domain.auction.eventBridge.dto;
+package com.example.auction.domain.auction.eventbridge.dto;
 
-import com.example.auction.domain.auction.eventBridge.entity.AuctionScheduleOutbox;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionScheduleOutbox;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/entity/AuctionCancelledEventBridge.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/entity/AuctionCancelledEventBridge.java
@@ -1,4 +1,4 @@
-package com.example.auction.domain.auction.eventBridge.entity;
+package com.example.auction.domain.auction.eventbridge.entity;
 
 public record AuctionCancelledEventBridge (
         Long auctionId

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/entity/AuctionCreatedEventBridge.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/entity/AuctionCreatedEventBridge.java
@@ -1,5 +1,4 @@
-
-package com.example.auction.domain.auction.eventBridge.entity;
+package com.example.auction.domain.auction.eventbridge.entity;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/entity/AuctionScheduleOutbox.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/entity/AuctionScheduleOutbox.java
@@ -1,4 +1,4 @@
-package com.example.auction.domain.auction.eventBridge.entity;
+package com.example.auction.domain.auction.eventbridge.entity;
 
 import com.example.auction.common.entity.CreatableEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/exception/OutboxErrorEnum.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/exception/OutboxErrorEnum.java
@@ -1,4 +1,4 @@
-package com.example.auction.domain.auction.eventBridge.exception;
+package com.example.auction.domain.auction.eventbridge.exception;
 
 import com.example.auction.common.exception.ErrorEnumInterface;
 import lombok.Getter;

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/repository/AuctionScheduleOutboxRepository.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/repository/AuctionScheduleOutboxRepository.java
@@ -1,6 +1,6 @@
-package com.example.auction.domain.auction.eventBridge.repository;
+package com.example.auction.domain.auction.eventbridge.repository;
 
-import com.example.auction.domain.auction.eventBridge.entity.AuctionScheduleOutbox;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionScheduleOutbox;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/service/AuctionEventBridgeService.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/service/AuctionEventBridgeService.java
@@ -1,9 +1,8 @@
+package com.example.auction.domain.auction.eventbridge.service;
 
-package com.example.auction.domain.auction.eventBridge.service;
-
-import com.example.auction.domain.auction.eventBridge.entity.AuctionCancelledEventBridge;
-import com.example.auction.domain.auction.eventBridge.entity.AuctionCreatedEventBridge;
-import com.example.auction.domain.auction.eventBridge.repository.AuctionScheduleOutboxRepository;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionCancelledEventBridge;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionCreatedEventBridge;
+import com.example.auction.domain.auction.eventbridge.repository.AuctionScheduleOutboxRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/service/AuctionOutboxWorker.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/service/AuctionOutboxWorker.java
@@ -1,7 +1,7 @@
-package com.example.auction.domain.auction.eventBridge.service;
+package com.example.auction.domain.auction.eventbridge.service;
 
-import com.example.auction.domain.auction.eventBridge.entity.AuctionScheduleOutbox;
-import com.example.auction.domain.auction.eventBridge.repository.AuctionScheduleOutboxRepository;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionScheduleOutbox;
+import com.example.auction.domain.auction.eventbridge.repository.AuctionScheduleOutboxRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;

--- a/src/main/java/com/example/auction/domain/auction/eventbridge/service/OutboxAdminService.java
+++ b/src/main/java/com/example/auction/domain/auction/eventbridge/service/OutboxAdminService.java
@@ -1,10 +1,10 @@
-package com.example.auction.domain.auction.eventBridge.service;
+package com.example.auction.domain.auction.eventbridge.service;
 
 import com.example.auction.common.exception.ServiceErrorException;
-import com.example.auction.domain.auction.eventBridge.dto.OutboxAdminResponse;
-import com.example.auction.domain.auction.eventBridge.entity.AuctionScheduleOutbox;
-import com.example.auction.domain.auction.eventBridge.exception.OutboxErrorEnum;
-import com.example.auction.domain.auction.eventBridge.repository.AuctionScheduleOutboxRepository;
+import com.example.auction.domain.auction.eventbridge.dto.OutboxAdminResponse;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionScheduleOutbox;
+import com.example.auction.domain.auction.eventbridge.exception.OutboxErrorEnum;
+import com.example.auction.domain.auction.eventbridge.repository.AuctionScheduleOutboxRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/auction/domain/auction/service/AuctionService.java
@@ -3,11 +3,10 @@ package com.example.auction.domain.auction.service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-import com.example.auction.domain.auction.eventBridge.entity.AuctionCancelledEventBridge;
-import com.example.auction.domain.auction.eventBridge.entity.AuctionCreatedEventBridge;
-import com.example.auction.domain.auction.eventBridge.entity.AuctionScheduleOutbox;
-import com.example.auction.domain.auction.eventBridge.repository.AuctionScheduleOutboxRepository;
-import com.example.auction.domain.auction.eventBridge.service.AuctionEventBridgeService;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionCancelledEventBridge;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionCreatedEventBridge;
+import com.example.auction.domain.auction.eventbridge.entity.AuctionScheduleOutbox;
+import com.example.auction.domain.auction.eventbridge.repository.AuctionScheduleOutboxRepository;
 import com.example.auction.domain.category.exception.CategoryErrorEnum;
 import com.example.auction.domain.category.repository.CategoryRepository;
 

--- a/src/test/java/com/example/auction/domain/ai/service/RagComparisonDemoTest.java
+++ b/src/test/java/com/example/auction/domain/ai/service/RagComparisonDemoTest.java
@@ -1,6 +1,6 @@
 package com.example.auction.domain.ai.service;
 
-import com.example.auction.domain.auction.eventBridge.service.AuctionEventBridgeService;
+import com.example.auction.domain.auction.eventbridge.service.AuctionEventBridgeService;
 import com.example.auction.testutils.BaseIntegrationTest;
 
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/com/example/auction/domain/auction/eventbridge/controller/OutboxAdminControllerTest.java
+++ b/src/test/java/com/example/auction/domain/auction/eventbridge/controller/OutboxAdminControllerTest.java
@@ -1,9 +1,9 @@
-package com.example.auction.domain.auction.eventBridge.controller;
+package com.example.auction.domain.auction.eventbridge.controller;
 
 import com.example.auction.common.config.security.CustomUserDetails;
 import com.example.auction.common.exception.GlobalExceptionHandler;
-import com.example.auction.domain.auction.eventBridge.dto.OutboxAdminResponse;
-import com.example.auction.domain.auction.eventBridge.service.OutboxAdminService;
+import com.example.auction.domain.auction.eventbridge.dto.OutboxAdminResponse;
+import com.example.auction.domain.auction.eventbridge.service.OutboxAdminService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
@coderabbitai ignore
## 📝 작업 내용
전체 리팩토링 후 머지 충돌 해결 과정에서 eventBridge(카멜케이스)와 eventbridge(소문자) 패키지가 중복으로 존재하는걸 확인
- 불필요한 찌꺼기 파일 제거 (eventbridge/AuctionCancelledEventBridge.java)
- 모든 파일의 package/import 선언을 eventbridge(소문자)로 통일
- 패키지명을 eventbridge(소문자)로 일괄 수정 (main, test 포함)

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항
현희님 확인 부탁드립니다,,,