### PR TITLE
[FEAT] ChatScheduler, UserChatScheduler에 ShedLock 적용

### DIFF
--- a/src/main/java/com/example/auction/domain/chat/scheduler/ChatScheduler.java
+++ b/src/main/java/com/example/auction/domain/chat/scheduler/ChatScheduler.java
@@ -3,6 +3,7 @@ package com.example.auction.domain.chat.scheduler;
 import com.example.auction.domain.chat.repository.ChatMessageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ public class ChatScheduler {
     // 시간 같은 경우는 나중에 비즈니스 로직 협의 이후 변경 예정
     @Transactional
     @Scheduled(cron = "0 0 0 * * *")
+    @SchedulerLock(name = "chatScheduler", lockAtMostFor = "PT10M", lockAtLeastFor = "PT1M")
     public void deleteOldMessages() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);
         int deleted = chatMessageRepository.deleteAllByCreatedAtBefore(threshold);

--- a/src/main/java/com/example/auction/domain/userchat/scheduler/UserChatScheduler.java
+++ b/src/main/java/com/example/auction/domain/userchat/scheduler/UserChatScheduler.java
@@ -3,6 +3,7 @@ package com.example.auction.domain.userchat.scheduler;
 import com.example.auction.domain.userchat.repository.UserChatMessageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ public class UserChatScheduler {
 
     @Transactional
     @Scheduled(cron = "0 0 0 * * *")
+    @SchedulerLock(name = "userChatScheduler", lockAtMostFor = "PT10M", lockAtLeastFor = "PT1M")
     public void deleteOldMessages() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);
         int deleted = userChatMessageRepository.deleteAllByCreatedAtBefore(threshold);


### PR DESCRIPTION
## 📝 작업 내용
- 30일 이전 메시지 삭제 스케줄러(ChatScheduler, UserChatScheduler)에 ShedLock 적용

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 분산 환경에서 스케줄된 메시지 정리 작업이 여러 인스턴스에서 동시에 실행되어 발생하는 중복 처리 문제를 해결했습니다. 이제 클러스터 환경에서도 안정적으로 메시지 정리가 수행됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GigaMak2/auction/pull/93)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->